### PR TITLE
Implement FavorAction, TwoCatAction, ThreeCatAction, and ComboValidator

### DIFF
--- a/src/main/java/domain/action/FavorAction.java
+++ b/src/main/java/domain/action/FavorAction.java
@@ -2,9 +2,25 @@ package domain.action;
 
 import domain.factory.PlayerInteractionHelper;
 import domain.model.GameState;
+import domain.model.Player;
+
+import java.util.List;
 
 public class FavorAction implements CardAction {
-    private PlayerInteractionHelper helper;
 
-    public void execute(GameState gameState) {}
+    private final PlayerInteractionHelper helper;
+
+    public FavorAction(PlayerInteractionHelper helper) {
+        this.helper = helper;
+    }
+
+    public void execute(GameState gameState) {
+        List<Player> others = gameState.getOtherActivePlayers();
+        if (others.isEmpty()) {
+            throw new IllegalStateException("No other active players to target");
+        }
+        Player target = helper.pickTarget(others);
+        Player current = gameState.getCurrentPlayer();
+        helper.giveCard(target, current);
+    }
 }

--- a/src/main/java/domain/action/ThreeCatAction.java
+++ b/src/main/java/domain/action/ThreeCatAction.java
@@ -1,10 +1,28 @@
 package domain.action;
 
+import domain.enums.CardType;
 import domain.factory.PlayerInteractionHelper;
 import domain.model.GameState;
+import domain.model.Player;
+
+import java.util.List;
 
 public class ThreeCatAction implements CardAction {
-    private PlayerInteractionHelper helper;
 
-    public void execute(GameState gameState) {}
+    private final PlayerInteractionHelper helper;
+
+    public ThreeCatAction(PlayerInteractionHelper helper) {
+        this.helper = helper;
+    }
+
+    public void execute(GameState gameState) {
+        List<Player> others = gameState.getOtherActivePlayers();
+        if (others.isEmpty()) {
+            throw new IllegalStateException("No other active players to target");
+        }
+        Player target = helper.pickTarget(others);
+        Player current = gameState.getCurrentPlayer();
+        CardType type = helper.pickCardType();
+        helper.stealNamedCard(target, current, type);
+    }
 }

--- a/src/main/java/domain/action/TwoCatAction.java
+++ b/src/main/java/domain/action/TwoCatAction.java
@@ -2,9 +2,25 @@ package domain.action;
 
 import domain.factory.PlayerInteractionHelper;
 import domain.model.GameState;
+import domain.model.Player;
+
+import java.util.List;
 
 public class TwoCatAction implements CardAction {
-    private PlayerInteractionHelper helper;
 
-    public void execute(GameState gameState) {}
+    private final PlayerInteractionHelper helper;
+
+    public TwoCatAction(PlayerInteractionHelper helper) {
+        this.helper = helper;
+    }
+
+    public void execute(GameState gameState) {
+        List<Player> others = gameState.getOtherActivePlayers();
+        if (others.isEmpty()) {
+            throw new IllegalStateException("No other active players to target");
+        }
+        Player target = helper.pickTarget(others);
+        Player current = gameState.getCurrentPlayer();
+        helper.stealRandomCard(target, current);
+    }
 }

--- a/src/main/java/domain/factory/ComboValidator.java
+++ b/src/main/java/domain/factory/ComboValidator.java
@@ -1,10 +1,59 @@
 package domain.factory;
 
-import domain.action.CardAction;
+import domain.action.*;
+import domain.enums.CardType;
 import domain.model.Card;
+
 import java.util.List;
 
 public class ComboValidator {
-    public boolean isValid(List<Card> cards) { return false; }
-    public CardAction resolveAction(List<Card> cards) { return null; }
+
+    private final PlayerInteractionHelper helper;
+
+    public ComboValidator(PlayerInteractionHelper helper) {
+        this.helper = helper;
+    }
+
+    public boolean isValid(List<Card> cards) {
+        if (cards == null || cards.isEmpty()) {
+            return false;
+        }
+        if (cards.size() == 1) {
+            Card card = cards.get(0);
+            return !card.isType(CardType.CAT_CARD)
+                    && !card.isType(CardType.EXPLODING_KITTEN)
+                    && !card.isType(CardType.DEFUSE);
+        }
+        if (cards.size() == 2 || cards.size() == 3) {
+            Card first = cards.get(0);
+            if (!first.isType(CardType.CAT_CARD)) {
+                return false;
+            }
+            for (Card card : cards) {
+                if (!card.isType(CardType.CAT_CARD) || !first.isSameName(card)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public CardAction resolveAction(List<Card> cards) {
+        if (!isValid(cards)) {
+            throw new IllegalArgumentException("Invalid combo");
+        }
+        if (cards.size() == 1) {
+            Card card = cards.get(0);
+            if (card.isType(CardType.SKIP)) return new SkipAction();
+            if (card.isType(CardType.ATTACK)) return new AttackAction();
+            if (card.isType(CardType.SHUFFLE)) return new ShuffleAction();
+            if (card.isType(CardType.SEE_THE_FUTURE)) return new SeeTheFutureAction();
+            if (card.isType(CardType.FAVOR)) return new FavorAction(helper);
+            if (card.isType(CardType.NOPE)) return new NopeAction();
+        }
+        if (cards.size() == 2) return new TwoCatAction(helper);
+        if (cards.size() == 3) return new ThreeCatAction(helper);
+        throw new IllegalArgumentException("Invalid combo");
+    }
 }

--- a/src/main/java/domain/factory/DeckFactory.java
+++ b/src/main/java/domain/factory/DeckFactory.java
@@ -9,15 +9,18 @@ import domain.model.Deck;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 public class DeckFactory {
 
     private final int numPlayers;
     private final IPlayerInput input;
+    private final PlayerInteractionHelper helper;
 
     public DeckFactory(int numPlayers, IPlayerInput input) {
         this.numPlayers = numPlayers;
         this.input = input;
+        this.helper = new PlayerInteractionHelper(input, new Random());
     }
 
     private static final int NUM_DEFUSE_CARDS = 6;
@@ -84,7 +87,7 @@ public class DeckFactory {
     List<Card> generateFavorCards() {
         List<Card> cards = new ArrayList<>();
         for (int i = 0; i < NUM_FAVOR_CARDS; i++) {
-            cards.add(new Card(CardType.FAVOR, CardName.FAVOR, new FavorAction()));
+            cards.add(new Card(CardType.FAVOR, CardName.FAVOR, new FavorAction(helper)));
         }
         return cards;
     }

--- a/src/main/java/domain/factory/PlayerInteractionHelper.java
+++ b/src/main/java/domain/factory/PlayerInteractionHelper.java
@@ -37,6 +37,14 @@ public class PlayerInteractionHelper {
         to.addCard(card);
     }
 
+    public Player pickTarget(List<Player> candidates) {
+        return input.promptTargetSelection(candidates);
+    }
+
+    public CardType pickCardType() {
+        return input.promptCardType();
+    }
+
     public void giveCard(Player from, Player to) {
         List<Card> selection = input.promptCardSelection(from);
         if (selection.isEmpty()) {

--- a/src/main/java/domain/input/IPlayerInput.java
+++ b/src/main/java/domain/input/IPlayerInput.java
@@ -1,5 +1,6 @@
 package domain.input;
 
+import domain.enums.CardType;
 import domain.model.Card;
 import domain.model.Player;
 
@@ -10,4 +11,6 @@ public interface IPlayerInput {
     int promptNumPlayers();
     boolean promptNope(List<Player> players);
     int promptInsertPosition(int deckSize);
+    Player promptTargetSelection(List<Player> candidates);
+    CardType promptCardType();
 }

--- a/src/main/java/domain/model/Card.java
+++ b/src/main/java/domain/model/Card.java
@@ -27,6 +27,10 @@ public class Card {
         this.action.execute(gameState);
     }
 
+    public boolean isSameName(Card other) {
+        return this.name == other.name;
+    }
+
     public void setAction(CardAction cardAction) {
         this.action = cardAction;
     }

--- a/src/main/java/domain/model/GameState.java
+++ b/src/main/java/domain/model/GameState.java
@@ -2,6 +2,7 @@ package domain.model;
 
 import domain.enums.CardType;
 import domain.enums.GameStatus;
+import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 
@@ -27,6 +28,7 @@ public class GameState {
     public void addCardToCurrentPlayer(Card card) {}
     public void removeCardFromCurrentPlayer(Card card) {}
     public boolean currentPlayerHasCard(CardType type) { return false; }
+    public List<Player> getOtherActivePlayers() { return Collections.emptyList(); }
     public List<Card> peekTopOfDeck(int n) { return null; }
     public int getDeckSize() { return 0; }
     public void insertPendingCardAt(int position) {}

--- a/src/main/java/ui/GameView.java
+++ b/src/main/java/ui/GameView.java
@@ -1,5 +1,6 @@
 package ui;
 
+import domain.enums.CardType;
 import domain.input.IPlayerInput;
 import domain.model.Card;
 import domain.model.GameState;
@@ -15,4 +16,6 @@ public class GameView implements IGameDisplay, IPlayerInput {
     public int promptNumPlayers() { return 0; }
     public boolean promptNope(List<Player> players) { return false; }
     public int promptInsertPosition(int deckSize) { return 0; }
+    public Player promptTargetSelection(List<Player> candidates) { throw new UnsupportedOperationException(); }
+    public CardType promptCardType() { throw new UnsupportedOperationException(); }
 }

--- a/src/test/java/domain/action/FavorActionTest.java
+++ b/src/test/java/domain/action/FavorActionTest.java
@@ -1,0 +1,92 @@
+package domain.action;
+
+import domain.factory.PlayerInteractionHelper;
+import domain.model.GameState;
+import domain.model.Player;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FavorActionTest {
+
+    private static Player player(String id) {
+        return new Player(id, id);
+    }
+
+    @Test
+    void execute_NoOtherActivePlayers_ThrowsIllegalStateException() {
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(Collections.emptyList());
+        EasyMock.replay(mockGameState, mockHelper);
+
+        assertThrows(IllegalStateException.class, () -> new FavorAction(mockHelper).execute(mockGameState));
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+
+    @Test
+    void execute_OneOtherPlayerEmptyHand_NoTransfer() {
+        Player current = player("current");
+        Player target = player("target");
+        List<Player> others = List.of(target);
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(others);
+        EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(current);
+        EasyMock.expect(mockHelper.pickTarget(others)).andReturn(target);
+        mockHelper.giveCard(target, current);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockGameState, mockHelper);
+
+        new FavorAction(mockHelper).execute(mockGameState);
+
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+
+    @Test
+    void execute_OneOtherPlayerOneCard_TransfersThatCard() {
+        Player current = player("current");
+        Player target = player("target");
+        List<Player> others = List.of(target);
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(others);
+        EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(current);
+        EasyMock.expect(mockHelper.pickTarget(others)).andReturn(target);
+        mockHelper.giveCard(target, current);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockGameState, mockHelper);
+
+        new FavorAction(mockHelper).execute(mockGameState);
+
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+
+    @Test
+    void execute_MultipleOtherPlayers_TransfersFromSelectedTarget() {
+        Player current = player("current");
+        Player target1 = player("target1");
+        Player target2 = player("target2");
+        List<Player> others = List.of(target1, target2);
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(others);
+        EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(current);
+        EasyMock.expect(mockHelper.pickTarget(others)).andReturn(target1);
+        mockHelper.giveCard(target1, current);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockGameState, mockHelper);
+
+        new FavorAction(mockHelper).execute(mockGameState);
+
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+}

--- a/src/test/java/domain/action/ThreeCatActionTest.java
+++ b/src/test/java/domain/action/ThreeCatActionTest.java
@@ -1,0 +1,95 @@
+package domain.action;
+
+import domain.enums.CardType;
+import domain.factory.PlayerInteractionHelper;
+import domain.model.GameState;
+import domain.model.Player;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ThreeCatActionTest {
+
+    private static Player player(String id) {
+        return new Player(id, id);
+    }
+
+    @Test
+    void execute_NoOtherActivePlayers_ThrowsIllegalStateException() {
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(Collections.emptyList());
+        EasyMock.replay(mockGameState, mockHelper);
+
+        assertThrows(IllegalStateException.class, () -> new ThreeCatAction(mockHelper).execute(mockGameState));
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+
+    @Test
+    void execute_TargetLacksNamedType_NoTransfer() {
+        Player current = player("current");
+        Player target = player("target");
+        List<Player> others = List.of(target);
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(others);
+        EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(current);
+        EasyMock.expect(mockHelper.pickTarget(others)).andReturn(target);
+        EasyMock.expect(mockHelper.pickCardType()).andReturn(CardType.SKIP);
+        mockHelper.stealNamedCard(target, current, CardType.SKIP);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockGameState, mockHelper);
+
+        new ThreeCatAction(mockHelper).execute(mockGameState);
+
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+
+    @Test
+    void execute_TargetHasNamedType_StealsIt() {
+        Player current = player("current");
+        Player target = player("target");
+        List<Player> others = List.of(target);
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(others);
+        EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(current);
+        EasyMock.expect(mockHelper.pickTarget(others)).andReturn(target);
+        EasyMock.expect(mockHelper.pickCardType()).andReturn(CardType.SKIP);
+        mockHelper.stealNamedCard(target, current, CardType.SKIP);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockGameState, mockHelper);
+
+        new ThreeCatAction(mockHelper).execute(mockGameState);
+
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+
+    @Test
+    void execute_TargetHasMultipleOfNamedType_StealsOne() {
+        Player current = player("current");
+        Player target = player("target");
+        List<Player> others = List.of(target);
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(others);
+        EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(current);
+        EasyMock.expect(mockHelper.pickTarget(others)).andReturn(target);
+        EasyMock.expect(mockHelper.pickCardType()).andReturn(CardType.SKIP);
+        mockHelper.stealNamedCard(target, current, CardType.SKIP);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockGameState, mockHelper);
+
+        new ThreeCatAction(mockHelper).execute(mockGameState);
+
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+}

--- a/src/test/java/domain/action/TwoCatActionTest.java
+++ b/src/test/java/domain/action/TwoCatActionTest.java
@@ -1,0 +1,91 @@
+package domain.action;
+
+import domain.factory.PlayerInteractionHelper;
+import domain.model.GameState;
+import domain.model.Player;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TwoCatActionTest {
+
+    private static Player player(String id) {
+        return new Player(id, id);
+    }
+
+    @Test
+    void execute_NoOtherActivePlayers_ThrowsIllegalStateException() {
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(Collections.emptyList());
+        EasyMock.replay(mockGameState, mockHelper);
+
+        assertThrows(IllegalStateException.class, () -> new TwoCatAction(mockHelper).execute(mockGameState));
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+
+    @Test
+    void execute_TargetHasNoCards_NoTransfer() {
+        Player current = player("current");
+        Player target = player("target");
+        List<Player> others = List.of(target);
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(others);
+        EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(current);
+        EasyMock.expect(mockHelper.pickTarget(others)).andReturn(target);
+        mockHelper.stealRandomCard(target, current);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockGameState, mockHelper);
+
+        new TwoCatAction(mockHelper).execute(mockGameState);
+
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+
+    @Test
+    void execute_TargetHasOneCard_StealsThatCard() {
+        Player current = player("current");
+        Player target = player("target");
+        List<Player> others = List.of(target);
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(others);
+        EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(current);
+        EasyMock.expect(mockHelper.pickTarget(others)).andReturn(target);
+        mockHelper.stealRandomCard(target, current);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockGameState, mockHelper);
+
+        new TwoCatAction(mockHelper).execute(mockGameState);
+
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+
+    @Test
+    void execute_TargetHasMultipleCards_StealsOneCard() {
+        Player current = player("current");
+        Player target = player("target");
+        List<Player> others = List.of(target);
+        GameState mockGameState = EasyMock.createMock(GameState.class);
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+
+        EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(others);
+        EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(current);
+        EasyMock.expect(mockHelper.pickTarget(others)).andReturn(target);
+        mockHelper.stealRandomCard(target, current);
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockGameState, mockHelper);
+
+        new TwoCatAction(mockHelper).execute(mockGameState);
+
+        EasyMock.verify(mockGameState, mockHelper);
+    }
+}

--- a/src/test/java/domain/factory/ComboValidatorTest.java
+++ b/src/test/java/domain/factory/ComboValidatorTest.java
@@ -1,0 +1,180 @@
+package domain.factory;
+
+import domain.action.*;
+import domain.enums.CardName;
+import domain.enums.CardType;
+import domain.model.Card;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ComboValidatorTest {
+
+    private static ComboValidator validator() {
+        PlayerInteractionHelper mockHelper = EasyMock.createMock(PlayerInteractionHelper.class);
+        EasyMock.replay(mockHelper);
+        return new ComboValidator(mockHelper);
+    }
+
+    private static Card card(CardType type, CardName name) {
+        return new Card(type, name, new NoAction());
+    }
+
+    // --- isValid ---
+
+    @Test
+    void isValid_NullList_ReturnsFalse() {
+        assertFalse(validator().isValid(null));
+    }
+
+    @Test
+    void isValid_EmptyList_ReturnsFalse() {
+        assertFalse(validator().isValid(List.of()));
+    }
+
+    @Test
+    void isValid_OneActionCard_ReturnsTrue() {
+        assertTrue(validator().isValid(List.of(card(CardType.SKIP, CardName.SKIP))));
+    }
+
+    @Test
+    void isValid_OneCatCard_ReturnsFalse() {
+        assertFalse(validator().isValid(List.of(card(CardType.CAT_CARD, CardName.TACO_CAT))));
+    }
+
+    @Test
+    void isValid_OneExplodingKitten_ReturnsFalse() {
+        assertFalse(validator().isValid(List.of(card(CardType.EXPLODING_KITTEN, CardName.EXPLODING_KITTEN))));
+    }
+
+    @Test
+    void isValid_OneDefuse_ReturnsFalse() {
+        assertFalse(validator().isValid(List.of(card(CardType.DEFUSE, CardName.DEFUSE))));
+    }
+
+    @Test
+    void isValid_TwoMatchingCatCards_ReturnsTrue() {
+        List<Card> cards = List.of(
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.TACO_CAT)
+        );
+        assertTrue(validator().isValid(cards));
+    }
+
+    @Test
+    void isValid_TwoDifferentCatCards_ReturnsFalse() {
+        List<Card> cards = List.of(
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.CATTERMELON)
+        );
+        assertFalse(validator().isValid(cards));
+    }
+
+    @Test
+    void isValid_TwoCardsOneNotCat_ReturnsFalse() {
+        List<Card> cards = List.of(
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.SKIP, CardName.SKIP)
+        );
+        assertFalse(validator().isValid(cards));
+    }
+
+    @Test
+    void isValid_ThreeMatchingCatCards_ReturnsTrue() {
+        List<Card> cards = List.of(
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.TACO_CAT)
+        );
+        assertTrue(validator().isValid(cards));
+    }
+
+    @Test
+    void isValid_ThreeDifferentCatCards_ReturnsFalse() {
+        List<Card> cards = List.of(
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.CATTERMELON),
+                card(CardType.CAT_CARD, CardName.BEARD_CAT)
+        );
+        assertFalse(validator().isValid(cards));
+    }
+
+    @Test
+    void isValid_FourOrMoreCards_ReturnsFalse() {
+        List<Card> cards = List.of(
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.TACO_CAT)
+        );
+        assertFalse(validator().isValid(cards));
+    }
+
+    // --- resolveAction ---
+
+    @Test
+    void resolveAction_OneSkip_ReturnsSkipAction() {
+        CardAction action = validator().resolveAction(List.of(card(CardType.SKIP, CardName.SKIP)));
+        assertInstanceOf(SkipAction.class, action);
+    }
+
+    @Test
+    void resolveAction_OneAttack_ReturnsAttackAction() {
+        CardAction action = validator().resolveAction(List.of(card(CardType.ATTACK, CardName.ATTACK)));
+        assertInstanceOf(AttackAction.class, action);
+    }
+
+    @Test
+    void resolveAction_OneShuffle_ReturnsShuffleAction() {
+        CardAction action = validator().resolveAction(List.of(card(CardType.SHUFFLE, CardName.SHUFFLE)));
+        assertInstanceOf(ShuffleAction.class, action);
+    }
+
+    @Test
+    void resolveAction_OneSeeFuture_ReturnsSeeTheFutureAction() {
+        CardAction action = validator().resolveAction(List.of(card(CardType.SEE_THE_FUTURE, CardName.SEE_THE_FUTURE)));
+        assertInstanceOf(SeeTheFutureAction.class, action);
+    }
+
+    @Test
+    void resolveAction_OneFavor_ReturnsFavorAction() {
+        CardAction action = validator().resolveAction(List.of(card(CardType.FAVOR, CardName.FAVOR)));
+        assertInstanceOf(FavorAction.class, action);
+    }
+
+    @Test
+    void resolveAction_OneNope_ReturnsNopeAction() {
+        CardAction action = validator().resolveAction(List.of(card(CardType.NOPE, CardName.NOPE)));
+        assertInstanceOf(NopeAction.class, action);
+    }
+
+    @Test
+    void resolveAction_TwoMatchingCats_ReturnsTwoCatAction() {
+        List<Card> cards = List.of(
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.TACO_CAT)
+        );
+        CardAction action = validator().resolveAction(cards);
+        assertInstanceOf(TwoCatAction.class, action);
+    }
+
+    @Test
+    void resolveAction_ThreeMatchingCats_ReturnsThreeCatAction() {
+        List<Card> cards = List.of(
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.TACO_CAT),
+                card(CardType.CAT_CARD, CardName.TACO_CAT)
+        );
+        CardAction action = validator().resolveAction(cards);
+        assertInstanceOf(ThreeCatAction.class, action);
+    }
+
+    @Test
+    void resolveAction_InvalidCombo_ThrowsIllegalArgumentException() {
+        List<Card> cards = List.of(card(CardType.CAT_CARD, CardName.TACO_CAT));
+        assertThrows(IllegalArgumentException.class, () -> validator().resolveAction(cards));
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented `FavorAction`, `TwoCatAction`, and `ThreeCatAction` with injected `PlayerInteractionHelper`
- Implemented `ComboValidator` with `isValid()` and `resolveAction()` methods
- Added supporting infrastructure: `pickTarget` and `pickCardType` on `PlayerInteractionHelper`, `getOtherActivePlayers` on `GameState`, `promptTargetSelection` and `promptCardType` on `IPlayerInput`, and `isSameName` on `Card`
- All actions throw `IllegalStateException` when no other active players exist
- Followed TDD: tests written first, then implementation

## Test plan
- [ ] `FavorActionTest` — 4 tests: no players, empty hand, one card, multiple players
- [ ] `TwoCatActionTest` — 4 tests: no players, no cards, one card, multiple cards
- [ ] `ThreeCatActionTest` — 4 tests: no players, type absent, type present, multiple of type
- [ ] `ComboValidatorTest` — 21 tests: null/empty/single/two/three card combos for `isValid` and `resolveAction`
- [ ] All existing tests still pass