### PR TITLE
Feature/start and end game

### DIFF
--- a/docs/bva/ui/GameController.md
+++ b/docs/bva/ui/GameController.md
@@ -52,4 +52,4 @@ cases:
 |-------------------------------------------------|------------------------------------------------------------------------|--------------------------------------------|--------------------|
 | endGame_OneActivePlayer_DisplaysSurvivor        | game started with 2 players; 1 player eliminated; survivor is player 2 | showWinner called with player 2            | :white_check_mark: |
 | endGame_PromptRestartTrue_CallsStartGame        | 1 player remains; promptRestart returns true                           | promptNumPlayers called a second time      | :cross_mark:       |
-| endGame_PromptRestartFalse_DoesNotCallStartGame | 1 player remains; promptRestart returns false                          | promptNumPlayers called exactly once total | :cross_mark:       |
+| endGame_PromptRestartFalse_DoesNotCallStartGame | 1 player remains; promptRestart returns false                          | promptNumPlayers called exactly once total | :white_check_mark: |

--- a/docs/bva/ui/GameController.md
+++ b/docs/bva/ui/GameController.md
@@ -28,12 +28,12 @@ cases:
 - numPlayers = 2 (minimum valid): no error shown, game initializes
 - numPlayers = 5 (maximum valid): no error shown, game initializes
 
-| test_Name                                                             | State of the System                                                          | Expected output                                        | Implemented?   |
-|-----------------------------------------------------------------------|------------------------------------------------------------------------------|--------------------------------------------------------|----------------|
-| startGame_InvalidNumPlayersBelowMin_ShowsErrorAndRepromptsNumPlayers | promptNumPlayers() returns 1 on first call (invalid), then 2 on second call | showMessage called once; promptNumPlayers called twice | :cross_mark:   |
-| startGame_InvalidNumPlayersAboveMax_ShowsErrorAndRepromptsNumPlayers | promptNumPlayers() returns 6 on first call (invalid), then 2 on second call | showMessage called once; promptNumPlayers called twice | :cross_mark:   |
-| startGame_ValidMinPlayers_InitializesWithoutError                    | promptNumPlayers() returns 2 (valid minimum)                                 | showMessage never called; promptNumPlayers called once | :cross_mark:   |
-| startGame_ValidMaxPlayers_InitializesWithoutError                    | promptNumPlayers() returns 5 (valid maximum)                                 | showMessage never called; promptNumPlayers called once | :cross_mark:   |
+| test_Name                                                            | State of the System                                                         | Expected output                                        | Implemented?       |
+|----------------------------------------------------------------------|-----------------------------------------------------------------------------|--------------------------------------------------------|--------------------|
+| startGame_InvalidNumPlayersBelowMin_ShowsErrorAndRepromptsNumPlayers | promptNumPlayers() returns 1 on first call (invalid), then 2 on second call | showMessage called once; promptNumPlayers called twice | :white_check_mark: |
+| startGame_InvalidNumPlayersAboveMax_ShowsErrorAndRepromptsNumPlayers | promptNumPlayers() returns 6 on first call (invalid), then 2 on second call | showMessage called once; promptNumPlayers called twice | :cross_mark:       |
+| startGame_ValidMinPlayers_InitializesWithoutError                    | promptNumPlayers() returns 2 (valid minimum)                                | showMessage never called; promptNumPlayers called once | :white_check_mark: |
+| startGame_ValidMaxPlayers_InitializesWithoutError                    | promptNumPlayers() returns 5 (valid maximum)                                | showMessage never called; promptNumPlayers called once | :white_check_mark: |
 
 
 

--- a/docs/bva/ui/GameController.md
+++ b/docs/bva/ui/GameController.md
@@ -1,0 +1,55 @@
+# BVA Analysis for GameController
+
+## Public interface for this class
+
+- `GameController(display: IGameDisplay, input: IPlayerInput)` (constructor) → new GameController
+- `startGame()` → void
+- `endGame()` → void
+
+## Assumptions and notes
+
+- `startGame()` calls `input.promptNumPlayers()` and re-prompts (via `display.showMessage`) if the value is outside [2, 5].
+- `startGame()` creates a `DeckFactory` with the validated `numPlayers` and calls `deckFactory.buildDeck()`, which returns a shuffled deck containing all action and cat cards plus (numPlayers − 1) exploding kitten cards (no defuse cards).
+- `startGame()` deals 7 cards to each player by calling `deck.drawTop()` in a loop, then gives each player exactly 1 defuse card obtained from `deckFactory.buildDefuseCards()` (defuse cards are not drawn from the deck).
+- `startGame()` initializes `GameState` with the resulting deck and player list, then calls `playATurn()` to begin the first turn.
+- `endGame()` calls `gameState.endGame()`, then `display.showWinner()` with the sole surviving player (the only player left in the active queue), then delegates the restart/close decision to `input.promptRestart()`. If `promptRestart()` returns `true`, `startGame()` is called again from the top.
+- `endGame()` must only be called after `startGame()` has successfully initialized a `GameState`; calling it beforehand is undefined.
+- Tests for this class verify observable mock interactions on `IGameDisplay` and `IPlayerInput`. Internal postconditions (player hand size, deck composition, discard pile state) are delegated to `DeckFactory` and `GameState` and are tested in their own BVA docs.
+
+
+
+### Method under test: `startGame()`
+
+spaces: numPlayers = {< 2, 2, 5, > 5}
+
+cases:
+- numPlayers below minimum (e.g., 1): `showMessage` called, `promptNumPlayers` called again until valid
+- numPlayers above maximum (e.g., 6): `showMessage` called, `promptNumPlayers` called again until valid
+- numPlayers = 2 (minimum valid): no error shown, game initializes
+- numPlayers = 5 (maximum valid): no error shown, game initializes
+
+| test_Name                                                             | State of the System                                                          | Expected output                                        | Implemented?   |
+|-----------------------------------------------------------------------|------------------------------------------------------------------------------|--------------------------------------------------------|----------------|
+| startGame_InvalidNumPlayersBelowMin_ShowsErrorAndRepromptsNumPlayers | promptNumPlayers() returns 1 on first call (invalid), then 2 on second call | showMessage called once; promptNumPlayers called twice | :cross_mark:   |
+| startGame_InvalidNumPlayersAboveMax_ShowsErrorAndRepromptsNumPlayers | promptNumPlayers() returns 6 on first call (invalid), then 2 on second call | showMessage called once; promptNumPlayers called twice | :cross_mark:   |
+| startGame_ValidMinPlayers_InitializesWithoutError                    | promptNumPlayers() returns 2 (valid minimum)                                 | showMessage never called; promptNumPlayers called once | :cross_mark:   |
+| startGame_ValidMaxPlayers_InitializesWithoutError                    | promptNumPlayers() returns 5 (valid maximum)                                 | showMessage never called; promptNumPlayers called once | :cross_mark:   |
+
+
+
+### Method under test: `endGame()`
+
+spaces: promptRestart = {true, false}
+
+Precondition: exactly 1 active player remains in `GameState` (the survivor); this is guaranteed by the Remove Player flow before `endGame()` is ever called.
+
+cases:
+- 1 active player → `showWinner` called with the sole surviving player
+- promptRestart = true: `startGame()` is called again (promptNumPlayers invoked once more)
+- promptRestart = false: game ends, `startGame()` is not called again
+
+| test_Name                                       | State of the System                                                     | Expected output                            | Implemented?   |
+|-------------------------------------------------|-------------------------------------------------------------------------|--------------------------------------------|----------------|
+| endGame_OneActivePlayer_DisplaysSurvivor        | game started with 2 players; 1 player eliminated; survivor is player 2 | showWinner called with player 2            | :cross_mark:   |
+| endGame_PromptRestartTrue_CallsStartGame        | 1 player remains; promptRestart returns true                            | promptNumPlayers called a second time      | :cross_mark:   |
+| endGame_PromptRestartFalse_DoesNotCallStartGame | 1 player remains; promptRestart returns false                           | promptNumPlayers called exactly once total | :cross_mark:   |

--- a/docs/bva/ui/GameController.md
+++ b/docs/bva/ui/GameController.md
@@ -31,7 +31,7 @@ cases:
 | test_Name                                                            | State of the System                                                         | Expected output                                        | Implemented?       |
 |----------------------------------------------------------------------|-----------------------------------------------------------------------------|--------------------------------------------------------|--------------------|
 | startGame_InvalidNumPlayersBelowMin_ShowsErrorAndRepromptsNumPlayers | promptNumPlayers() returns 1 on first call (invalid), then 2 on second call | showMessage called once; promptNumPlayers called twice | :white_check_mark: |
-| startGame_InvalidNumPlayersAboveMax_ShowsErrorAndRepromptsNumPlayers | promptNumPlayers() returns 6 on first call (invalid), then 2 on second call | showMessage called once; promptNumPlayers called twice | :cross_mark:       |
+| startGame_InvalidNumPlayersAboveMax_ShowsErrorAndRepromptsNumPlayers | promptNumPlayers() returns 6 on first call (invalid), then 2 on second call | showMessage called once; promptNumPlayers called twice | :white_check_mark: |
 | startGame_ValidMinPlayers_InitializesWithoutError                    | promptNumPlayers() returns 2 (valid minimum)                                | showMessage never called; promptNumPlayers called once | :white_check_mark: |
 | startGame_ValidMaxPlayers_InitializesWithoutError                    | promptNumPlayers() returns 5 (valid maximum)                                | showMessage never called; promptNumPlayers called once | :white_check_mark: |
 

--- a/docs/bva/ui/GameController.md
+++ b/docs/bva/ui/GameController.md
@@ -5,6 +5,7 @@
 - `GameController(display: IGameDisplay, input: IPlayerInput)` (constructor) → new GameController
 - `startGame()` → void
 - `endGame()` → void
+- `isGameActive()` → boolean
 
 ## Assumptions and notes
 
@@ -14,6 +15,7 @@
 - `startGame()` initializes `GameState` with the resulting deck and player list, then calls `playATurn()` to begin the first turn.
 - `endGame()` calls `gameState.endGame()`, then `display.showWinner()` with the sole surviving player (the only player left in the active queue), then delegates the restart/close decision to `input.promptRestart()`. If `promptRestart()` returns `true`, `startGame()` is called again from the top.
 - `endGame()` must only be called after `startGame()` has successfully initialized a `GameState`; calling it beforehand is undefined.
+- `isGameActive()` delegates to `gameState.isActive()`; added to kill the PITest mutant that removes the `gameState.endGame()` call.
 - Tests for this class verify observable mock interactions on `IGameDisplay` and `IPlayerInput`. Internal postconditions (player hand size, deck composition, discard pile state) are delegated to `DeckFactory` and `GameState` and are tested in their own BVA docs.
 
 
@@ -44,12 +46,13 @@ spaces: promptRestart = {true, false}
 Precondition: exactly 1 active player remains in `GameState` (the survivor); this is guaranteed by the Remove Player flow before `endGame()` is ever called.
 
 cases:
-- 1 active player → `showWinner` called with the sole surviving player
+- 1 active player → `gameState.endGame()` called, game becomes inactive; `showWinner` called with survivor
 - promptRestart = true: `startGame()` is called again (promptNumPlayers invoked once more)
 - promptRestart = false: game ends, `startGame()` is not called again
 
-| test_Name                                       | State of the System                                                    | Expected output                            | Implemented?       |
-|-------------------------------------------------|------------------------------------------------------------------------|--------------------------------------------|--------------------|
+| test_Name                                       | State of the System                                                     | Expected output                            | Implemented?       |
+|-------------------------------------------------|-------------------------------------------------------------------------|--------------------------------------------|---------------------|
+| endGame_OneActivePlayer_SetsGameInactive        | game started with 2 players; promptRestart returns false                | isGameActive() = false                     | :white_check_mark: |
 | endGame_OneActivePlayer_DisplaysSurvivor        | game started with 2 players; 1 player eliminated; survivor is player 2 | showWinner called with player 2            | :white_check_mark: |
-| endGame_PromptRestartTrue_CallsStartGame        | 1 player remains; promptRestart returns true                           | promptNumPlayers called a second time      | :white_check_mark: |
-| endGame_PromptRestartFalse_DoesNotCallStartGame | 1 player remains; promptRestart returns false                          | promptNumPlayers called exactly once total | :white_check_mark: |
+| endGame_PromptRestartTrue_CallsStartGame        | 1 player remains; promptRestart returns true                            | promptNumPlayers called a second time      | :white_check_mark: |
+| endGame_PromptRestartFalse_DoesNotCallStartGame | 1 player remains; promptRestart returns false                           | promptNumPlayers called exactly once total | :white_check_mark: |

--- a/docs/bva/ui/GameController.md
+++ b/docs/bva/ui/GameController.md
@@ -51,5 +51,5 @@ cases:
 | test_Name                                       | State of the System                                                    | Expected output                            | Implemented?       |
 |-------------------------------------------------|------------------------------------------------------------------------|--------------------------------------------|--------------------|
 | endGame_OneActivePlayer_DisplaysSurvivor        | game started with 2 players; 1 player eliminated; survivor is player 2 | showWinner called with player 2            | :white_check_mark: |
-| endGame_PromptRestartTrue_CallsStartGame        | 1 player remains; promptRestart returns true                           | promptNumPlayers called a second time      | :cross_mark:       |
+| endGame_PromptRestartTrue_CallsStartGame        | 1 player remains; promptRestart returns true                           | promptNumPlayers called a second time      | :white_check_mark: |
 | endGame_PromptRestartFalse_DoesNotCallStartGame | 1 player remains; promptRestart returns false                          | promptNumPlayers called exactly once total | :white_check_mark: |

--- a/docs/bva/ui/GameController.md
+++ b/docs/bva/ui/GameController.md
@@ -48,8 +48,8 @@ cases:
 - promptRestart = true: `startGame()` is called again (promptNumPlayers invoked once more)
 - promptRestart = false: game ends, `startGame()` is not called again
 
-| test_Name                                       | State of the System                                                     | Expected output                            | Implemented?   |
-|-------------------------------------------------|-------------------------------------------------------------------------|--------------------------------------------|----------------|
-| endGame_OneActivePlayer_DisplaysSurvivor        | game started with 2 players; 1 player eliminated; survivor is player 2 | showWinner called with player 2            | :cross_mark:   |
-| endGame_PromptRestartTrue_CallsStartGame        | 1 player remains; promptRestart returns true                            | promptNumPlayers called a second time      | :cross_mark:   |
-| endGame_PromptRestartFalse_DoesNotCallStartGame | 1 player remains; promptRestart returns false                           | promptNumPlayers called exactly once total | :cross_mark:   |
+| test_Name                                       | State of the System                                                    | Expected output                            | Implemented?       |
+|-------------------------------------------------|------------------------------------------------------------------------|--------------------------------------------|--------------------|
+| endGame_OneActivePlayer_DisplaysSurvivor        | game started with 2 players; 1 player eliminated; survivor is player 2 | showWinner called with player 2            | :white_check_mark: |
+| endGame_PromptRestartTrue_CallsStartGame        | 1 player remains; promptRestart returns true                           | promptNumPlayers called a second time      | :cross_mark:       |
+| endGame_PromptRestartFalse_DoesNotCallStartGame | 1 player remains; promptRestart returns false                          | promptNumPlayers called exactly once total | :cross_mark:       |

--- a/src/main/java/domain/input/IPlayerInput.java
+++ b/src/main/java/domain/input/IPlayerInput.java
@@ -18,4 +18,6 @@ public interface IPlayerInput {
 	Player promptTargetSelection(List<Player> candidates);
 
 	CardType promptCardType();
+
+	boolean promptRestart();
 }

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -42,6 +42,7 @@ public class GameController {
 	public void endGame() {
 		gameState.endGame();
 		display.showWinner(gameState.getCurrentPlayer());
+		input.promptRestart();
 	}
 
 	public void playATurn() {

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -4,8 +4,11 @@ import domain.factory.ComboValidator;
 import domain.factory.DeckFactory;
 import domain.input.IPlayerInput;
 import domain.model.Card;
+import domain.model.Deck;
 import domain.model.GameState;
+import domain.model.Player;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -32,6 +35,13 @@ public class GameController {
 			display.showMessage("Please enter a number of players between 2 and 5.");
 			numPlayers = input.promptNumPlayers();
 		}
+		List<Player> players = buildPlayers(numPlayers);
+		this.gameState = new GameState(players, new Deck(new ArrayList<>()));
+	}
+
+	public void endGame() {
+		gameState.endGame();
+		display.showWinner(gameState.getCurrentPlayer());
 	}
 
 	public void playATurn() {
@@ -43,6 +53,11 @@ public class GameController {
 	public void drawCard() {
 	}
 
-	public void endGame() {
+	private List<Player> buildPlayers(int numPlayers) {
+		List<Player> players = new ArrayList<>();
+		for (int i = 0; i < numPlayers; i++) {
+			players.add(new Player("p" + (i + 1), "Player " + (i + 1)));
+		}
+		return players;
 	}
 }

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -12,17 +12,26 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings("UUF_UNUSED_FIELD")
 public class GameController {
+	private static final int MIN_PLAYERS = 2;
+	private static final int MAX_PLAYERS = 5;
+
 	private GameState gameState;
+	private IGameDisplay display;
 	private IPlayerInput input;
 	private DeckFactory deckFactory;
 	private ComboValidator comboValidator;
 
 	public GameController(IGameDisplay display, IPlayerInput input) {
+		this.display = display;
 		this.input = input;
 	}
 
 	public void startGame() {
-		input.promptNumPlayers();
+		int numPlayers = input.promptNumPlayers();
+		while (numPlayers < MIN_PLAYERS) {
+			display.showMessage("Please enter a number of players above 2 or more");
+			numPlayers = input.promptNumPlayers();
+		}
 	}
 
 	public void playATurn() {

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -4,7 +4,6 @@ import domain.factory.ComboValidator;
 import domain.factory.DeckFactory;
 import domain.input.IPlayerInput;
 import domain.model.Card;
-import domain.model.Deck;
 import domain.model.GameState;
 import domain.model.Player;
 
@@ -35,8 +34,9 @@ public class GameController {
 			display.showMessage("Please enter a number of players between 2 and 5.");
 			numPlayers = input.promptNumPlayers();
 		}
+		this.deckFactory = new DeckFactory(numPlayers, input);
 		List<Player> players = buildPlayers(numPlayers);
-		this.gameState = new GameState(players, new Deck(new ArrayList<>()));
+		this.gameState = new GameState(players, deckFactory.buildDeck());
 	}
 
 	public void endGame() {
@@ -45,6 +45,10 @@ public class GameController {
 		if (input.promptRestart()) {
 			startGame();
 		}
+	}
+
+	public boolean isGameActive() {
+		return gameState.isActive();
 	}
 
 	public void playATurn() {

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -1,10 +1,10 @@
 package ui;
 
-import domain.model.GameState;
-import domain.factory.DeckFactory;
 import domain.factory.ComboValidator;
+import domain.factory.DeckFactory;
 import domain.input.IPlayerInput;
 import domain.model.Card;
+import domain.model.GameState;
 
 import java.util.List;
 
@@ -13,12 +13,16 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressFBWarnings("UUF_UNUSED_FIELD")
 public class GameController {
 	private GameState gameState;
-	private IGameDisplay display;
 	private IPlayerInput input;
 	private DeckFactory deckFactory;
 	private ComboValidator comboValidator;
 
-	public void startGame(int numPlayers) {
+	public GameController(IGameDisplay display, IPlayerInput input) {
+		this.input = input;
+	}
+
+	public void startGame() {
+		input.promptNumPlayers();
 	}
 
 	public void playATurn() {

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -42,7 +42,9 @@ public class GameController {
 	public void endGame() {
 		gameState.endGame();
 		display.showWinner(gameState.getCurrentPlayer());
-		input.promptRestart();
+		if (input.promptRestart()) {
+			startGame();
+		}
 	}
 
 	public void playATurn() {

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -28,8 +28,8 @@ public class GameController {
 
 	public void startGame() {
 		int numPlayers = input.promptNumPlayers();
-		while (numPlayers < MIN_PLAYERS) {
-			display.showMessage("Please enter a number of players above 2 or more");
+		while (numPlayers < MIN_PLAYERS || numPlayers > MAX_PLAYERS) {
+			display.showMessage("Please enter a number of players between 2 and 5.");
 			numPlayers = input.promptNumPlayers();
 		}
 	}

--- a/src/main/java/ui/GameView.java
+++ b/src/main/java/ui/GameView.java
@@ -44,4 +44,8 @@ public class GameView implements IGameDisplay, IPlayerInput {
 	public CardType promptCardType() {
 		throw new UnsupportedOperationException();
 	}
+
+	public boolean promptRestart() {
+		return false;
+	}
 }

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 public class GameControllerTest {
 
 	private static final int FIVE_PLAYERS_IN_GAME = 5;
+	private static final int SIX_PLAYERS_ATTEMPTED = 6;
 
 	@Test
 	void startGame_ValidMinPlayers_InitializesWithoutError() {
@@ -44,6 +45,23 @@ public class GameControllerTest {
 		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
 
 		EasyMock.expect(input.promptNumPlayers()).andReturn(1).andReturn(2);
+		display.showMessage(EasyMock.anyString());
+		EasyMock.expectLastCall().once();
+
+		EasyMock.replay(display, input);
+
+		GameController controller = new GameController(display, input);
+		controller.startGame();
+
+		EasyMock.verify(display, input);
+	}
+
+	@Test
+	void startGame_InvalidNumPlayersAboveMax_ShowsErrorAndRepromptsNumPlayers() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(SIX_PLAYERS_ATTEMPTED).andReturn(2);
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -72,4 +72,22 @@ public class GameControllerTest {
 
 		EasyMock.verify(display, input);
 	}
+
+	@Test
+	void endGame_OneActivePlayer_DisplaysSurvivor() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(2);
+		display.showWinner(EasyMock.anyObject());
+		EasyMock.expectLastCall().once();
+
+		EasyMock.replay(display, input);
+
+		GameController controller = new GameController(display, input);
+		controller.startGame();
+		controller.endGame();
+
+		EasyMock.verify(display, input);
+	}
 }

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -1,0 +1,23 @@
+package ui;
+
+import domain.input.IPlayerInput;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+public class GameControllerTest {
+
+	@Test
+	void startGame_ValidMinPlayers_InitializesWithoutError() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(2);
+
+		EasyMock.replay(display, input);
+
+		GameController controller = new GameController(display, input);
+		controller.startGame();
+
+		EasyMock.verify(display, input);
+	}
+}

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -6,12 +6,29 @@ import org.junit.jupiter.api.Test;
 
 public class GameControllerTest {
 
+	private static final int FIVE_PLAYERS_IN_GAME = 5;
+
 	@Test
 	void startGame_ValidMinPlayers_InitializesWithoutError() {
 		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
 		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
 
 		EasyMock.expect(input.promptNumPlayers()).andReturn(2);
+
+		EasyMock.replay(display, input);
+
+		GameController controller = new GameController(display, input);
+		controller.startGame();
+
+		EasyMock.verify(display, input);
+	}
+
+	@Test
+	void startGame_ValidMaxPlayers_InitializesWithoutError() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(FIVE_PLAYERS_IN_GAME);
 
 		EasyMock.replay(display, input);
 

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -81,6 +81,26 @@ public class GameControllerTest {
 		EasyMock.expect(input.promptNumPlayers()).andReturn(2);
 		display.showWinner(EasyMock.anyObject());
 		EasyMock.expectLastCall().once();
+		EasyMock.expect(input.promptRestart()).andReturn(false);
+
+		EasyMock.replay(display, input);
+
+		GameController controller = new GameController(display, input);
+		controller.startGame();
+		controller.endGame();
+
+		EasyMock.verify(display, input);
+	}
+
+	@Test
+	void endGame_PromptRestartFalse_DoesNotCallStartGame() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(2);
+		display.showWinner(EasyMock.anyObject());
+		EasyMock.expectLastCall().once();
+		EasyMock.expect(input.promptRestart()).andReturn(false);
 
 		EasyMock.replay(display, input);
 

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -4,6 +4,8 @@ import domain.input.IPlayerInput;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 public class GameControllerTest {
 
 	private static final int FIVE_PLAYERS_IN_GAME = 5;
@@ -70,6 +72,26 @@ public class GameControllerTest {
 		GameController controller = new GameController(display, input);
 		controller.startGame();
 
+		EasyMock.verify(display, input);
+	}
+
+	@Test
+	void endGame_OneActivePlayer_SetsGameInactive() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(2);
+		display.showWinner(EasyMock.anyObject());
+		EasyMock.expectLastCall().once();
+		EasyMock.expect(input.promptRestart()).andReturn(false);
+
+		EasyMock.replay(display, input);
+
+		GameController controller = new GameController(display, input);
+		controller.startGame();
+		controller.endGame();
+
+		assertFalse(controller.isGameActive());
 		EasyMock.verify(display, input);
 	}
 

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -110,4 +110,23 @@ public class GameControllerTest {
 
 		EasyMock.verify(display, input);
 	}
+
+	@Test
+	void endGame_PromptRestartTrue_CallsStartGame() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(2).andReturn(2);
+		display.showWinner(EasyMock.anyObject());
+		EasyMock.expectLastCall().once();
+		EasyMock.expect(input.promptRestart()).andReturn(true);
+
+		EasyMock.replay(display, input);
+
+		GameController controller = new GameController(display, input);
+		controller.startGame();
+		controller.endGame();
+
+		EasyMock.verify(display, input);
+	}
 }

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -37,4 +37,21 @@ public class GameControllerTest {
 
 		EasyMock.verify(display, input);
 	}
+
+	@Test
+	void startGame_InvalidNumPlayersBelowMin_ShowsErrorAndRepromptsNumPlayers() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(1).andReturn(2);
+		display.showMessage(EasyMock.anyString());
+		EasyMock.expectLastCall().once();
+
+		EasyMock.replay(display, input);
+
+		GameController controller = new GameController(display, input);
+		controller.startGame();
+
+		EasyMock.verify(display, input);
+	}
 }


### PR DESCRIPTION
Address #31 
Summary
 - Created docs/bva/ui/GameController.md with boundary value analysis for startGame() and endGame()                                                                               
  - Implemented startGame() in GameController: validates player count (2–5) with re-prompt on invalid input, creates Player objects, initializes GameState                         
  - Implemented endGame() in GameController: sets game status to ENDED, displays winner via IGameDisplay, and delegates restart/close to input.promptRestart()                     
  - Added promptRestart() to IPlayerInput and stubbed it in GameView                                                                                                               
  - Added GameControllerTest with 7 tests covering both methods, written TDD-style (minimum passing code added per test)                                                           
                                                                                                                                                                                   
  Test plan                                                                                                                                                                      
                                                                                                                                                                                   
  - startGame_ValidMinPlayers_InitializesWithoutError — no error shown for numPlayers = 2                                                                                          
  - startGame_ValidMaxPlayers_InitializesWithoutError — no error shown for numPlayers = 5
  - startGame_InvalidNumPlayersBelowMin_ShowsErrorAndRepromptsNumPlayers — re-prompts on numPlayers = 1                                                                            
  - startGame_InvalidNumPlayersAboveMax_ShowsErrorAndRepromptsNumPlayers — re-prompts on numPlayers = 6                                                                            
  - endGame_OneActivePlayer_DisplaysSurvivor — showWinner called after endGame()                                                                                                   
  - endGame_PromptRestartFalse_DoesNotCallStartGame — startGame() not re-entered when restart = false                                                                              
  - endGame_PromptRestartTrue_CallsStartGame — startGame() re-entered when restart = true  