### PR TITLE
Refactor/prof yiji code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Gradle Build](https://github.com/nu-cs-sqe/course-explodingwildkittens-20252603-team-03-20252603/actions/workflows/main.yml/badge.svg)
 
 [![Open in Codespaces](https://classroom.github.com/assets/launch-codespace-2972f46106e565e64193e422d61a12cf1da4916b45550586e14ef0a7c637dd04.svg)](https://classroom.github.com/open-in-codespaces?assignment_repo_id=23631080)
-# PROJECT NAME
+# Exploding Wildkittens
 
 ## Contributors
 - Caroline Guerra
@@ -13,6 +13,12 @@
 - JDK 11
 - JUnit 5.10
 - Gradle 8.10
+
+## Checkstyle Exceptions
+
+### `GameController`: 4-parameter constructor
+
+The linter flags constructors with more than 3 parameters. `GameController` is an intentional exception: its 4 parameters (`GameState`, `IGameDisplay`, `IPlayerInput`, `ComboValidator`) are each distinct collaborators specified in `design.puml`. Merging any two would create a meaningless wrapper. This is the only place in the codebase where the limit is exceeded.
 
 ## Acknowledgements
 Claude AI Usage

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -35,10 +35,10 @@
             <message key="maxLen.method" value="Method length is {0} lines (max 20). Methods should do one thing only."/>
         </module>
 
-        <!-- Limit parameters: max 3, flag 4+; GameController constructor is an intentional exception (4 params per design.puml) -->
+        <!-- Limit parameters: max 3, flag 4+, exception for GameController explained in README.md -->
         <module name="ParameterNumber">
-            <property name="max" value="4"/>
-            <message key="maxParam" value="Method has {0} parameters (max 4). Consider grouping into a class."/>
+            <property name="max" value="3"/>
+            <message key="maxParam" value="Method has {0} parameters (max 3). Consider grouping into a class."/>
         </module>
 
         <!-- ===== CLASSES (Clean Code Ch. 10) ===== -->

--- a/docs/design/use-cases.md
+++ b/docs/design/use-cases.md
@@ -1,4 +1,4 @@
-# User Stories
+# Use Cases
 
 ---
 

--- a/src/main/java/domain/factory/ComboValidator.java
+++ b/src/main/java/domain/factory/ComboValidator.java
@@ -4,6 +4,7 @@ import domain.action.*;
 import domain.enums.CardType;
 import domain.model.Card;
 
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -50,18 +51,22 @@ public class ComboValidator {
 			ResourceBundle bundle = ResourceBundle.getBundle("labels", Locale.getDefault());
 			throw new IllegalArgumentException(bundle.getString("error.invalid.combo"));
 		}
-		if (cards.size() == 1) {
-			Card card = cards.get(0);
-			if (card.isType(CardType.SKIP)) { return new SkipAction(); }
-			if (card.isType(CardType.ATTACK)) { return new AttackAction(); }
-			if (card.isType(CardType.SHUFFLE)) { return new ShuffleAction(); }
-			if (card.isType(CardType.SEE_THE_FUTURE)) { return new SeeTheFutureAction(); }
-			if (card.isType(CardType.FAVOR)) { return new FavorAction(helper); }
-			if (card.isType(CardType.NOPE)) { return new NopeAction(); }
-		}
+		if (cards.size() == 1) { return resolveSingleCard(cards.get(0)); }
 		if (cards.size() == 2) { return new TwoCatAction(helper); }
-
 		return new ThreeCatAction(helper);
+	}
 
+	private CardAction resolveSingleCard(Card card) {
+		if (card.isType(CardType.SKIP)) { return new SkipAction(); }
+		else if (card.isType(CardType.ATTACK)) { return new AttackAction(); }
+		else if (card.isType(CardType.SHUFFLE)) { return new ShuffleAction(); }
+		else if (card.isType(CardType.SEE_THE_FUTURE)) { return new SeeTheFutureAction(); }
+		else if (card.isType(CardType.FAVOR)) { return new FavorAction(helper); }
+		else if (card.isType(CardType.NOPE)) { return new NopeAction(); }
+		else {
+			ResourceBundle bundle = ResourceBundle.getBundle("labels", Locale.getDefault());
+			throw new IllegalArgumentException(
+				MessageFormat.format(bundle.getString("error.unsupported.card.type"), card));
+		}
 	}
 }

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -37,6 +37,7 @@ public class GameController {
 	}
 
 	// 4 params: design.puml requires gameState, display, input, and comboValidator as distinct dependencies
+	@SuppressWarnings("checkstyle:ParameterNumber")
 	@SuppressFBWarnings("EI_EXPOSE_REP2")
 	public GameController(GameState gameState, IGameDisplay display,
 		IPlayerInput input, ComboValidator comboValidator){

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -12,6 +12,7 @@ error.index.out.of.bounds=Index out of bounds: {0,number,integer}
 error.peek.exceeds.deck=Error: card number requested exceeds size of deck
 error.no.other.players=No other active players to target
 error.invalid.combo=Invalid combo
+error.unsupported.card.type=Unsupported card type: {0}
 error.card.arg.null=card must not be null
 error.cards.arg.null=cards must not be null
 error.not.ready.to.play=Game state is not ready to play a turn


### PR DESCRIPTION
Addresses #63 

Refactor ComboValidator, tighten linter rule, and rename design doc
  
  - ComboValidator#resolveAction: replaced flat if chain with if / else if / else to make mutual exclusivity explicit; the else branch throws an IllegalArgumentException via MessageFormat + i18n key
  (error.unsupported.card.type) for any unhandled card type. Single-card logic extracted into private resolveSingleCard helper to satisfy the 20-line method limit.
  - Checkstyle + GameController: reverted ParameterNumber max from 4 back to 3; added @SuppressWarnings("checkstyle:ParameterNumber") to the GameController constructor (the one intentional 4-param
  exception per design.puml). README documents the exception with the correct parameter names.
  - Docs: renamed user-stories.md → use-cases.md per feedback from Prof. Yiji.
