### PR TITLE
testing: fix coverage gaps in UI layer (issue #65)

### DIFF
--- a/src/test/java/domain/action/NoActionTest.java
+++ b/src/test/java/domain/action/NoActionTest.java
@@ -1,0 +1,16 @@
+package domain.action;
+
+import domain.model.GameState;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+public class NoActionTest {
+
+	@Test
+	void execute_AnyGameState_DoesNothing() {
+		GameState mockGameState = EasyMock.createMock(GameState.class);
+		EasyMock.replay(mockGameState);
+		new NoAction().execute(mockGameState);
+		EasyMock.verify(mockGameState);
+	}
+}

--- a/src/test/java/ui/GameViewTest.java
+++ b/src/test/java/ui/GameViewTest.java
@@ -20,6 +20,7 @@ import java.util.Scanner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -88,6 +89,11 @@ public class GameViewTest {
 		EasyMock.expect(mockTurnState.turnsRemaining()).andReturn(TURNS_REMAINING);
 		EasyMock.replay(mockGameState, mockTurnState);
 		return mockGameState;
+	}
+
+	@Test
+	void gameView_DefaultConstructor_CreatesInstance() {
+		assertNotNull(new GameView());
 	}
 
 	@Test

--- a/src/test/java/ui/GameViewTest.java
+++ b/src/test/java/ui/GameViewTest.java
@@ -281,4 +281,75 @@ public class GameViewTest {
 		PlayerChoice choice = createView("2\n").promptPlayerChoice();
 		assertEquals(PlayerChoice.DONE_PLAYING_CARDS, choice);
 	}
+
+	@Test
+	void promptNumPlayers_NoInput_ThrowsIllegalStateException() {
+		assertThrows(IllegalStateException.class, () -> createView("").promptNumPlayers());
+	}
+
+	@Test
+	void promptNope_NoInput_ThrowsIllegalStateException() {
+		Player mockPlayer = mockNamedPlayer("Bob");
+		assertThrows(IllegalStateException.class, () -> createView("").promptNope(mockPlayer));
+		EasyMock.verify(mockPlayer);
+	}
+
+	@Test
+	void promptInsertPosition_BelowMin_PromptsAgain() {
+		int position = createView("-1\n0\n").promptInsertPosition(DECK_SIZE);
+		assertEquals(0, position);
+	}
+
+	@Test
+	void promptTargetSelection_NegativeIndex_PromptsAgain() {
+		Player first = new Player("p1", "Alice");
+		Player second = new Player("p2", "Bob");
+		Player chosen = createView("0\n2\n").promptTargetSelection(List.of(first, second));
+		assertEquals(second, chosen);
+	}
+
+	@Test
+	void promptCardSelection_NegativeIndex_ReturnsEmptyList() {
+		Player mockPlayer = mockPlayerWithHand("Alice", List.of(skipCard()));
+		List<Card> selected = createView("0\n").promptCardSelection(mockPlayer);
+		assertTrue(selected.isEmpty());
+		EasyMock.verify(mockPlayer);
+	}
+
+	@Test
+	void promptCardSelection_NonNumericToken_ReturnsEmptyList() {
+		Player mockPlayer = mockPlayerWithHand("Alice", List.of(skipCard()));
+		List<Card> selected = createView("abc\n").promptCardSelection(mockPlayer);
+		assertTrue(selected.isEmpty());
+		EasyMock.verify(mockPlayer);
+	}
+
+	@Test
+	void promptCardSelection_LeadingComma_SkipsEmptyToken() {
+		Card card = skipCard();
+		Player mockPlayer = mockPlayerWithHand("Alice", List.of(card));
+		List<Card> selected = createView(",1\n").promptCardSelection(mockPlayer);
+		assertEquals(SINGLE_CARD, selected.size());
+		EasyMock.verify(mockPlayer);
+	}
+
+	@Test
+	void promptCardType_InvalidThenValid_LoopsAndReturnsType() {
+		CardType type = createView("0\n1\n").promptCardType();
+		assertEquals(CardType.EXPLODING_KITTEN, type);
+	}
+
+	@Test
+	void showPlayerHand_UnknownCard_PrintsUnknown() {
+		Card mockCard = EasyMock.createMock(Card.class);
+		EasyMock.expect(mockCard.isName(EasyMock.anyObject(CardName.class))).andReturn(false).anyTimes();
+		Player mockPlayer = EasyMock.createMock(Player.class);
+		EasyMock.expect(mockPlayer.getName()).andReturn("Alice").anyTimes();
+		EasyMock.expect(mockPlayer.getHand()).andReturn(List.of(mockCard)).anyTimes();
+		EasyMock.expect(mockPlayer.getPeekCards()).andReturn(List.of()).anyTimes();
+		EasyMock.replay(mockCard, mockPlayer);
+		createView("").showPlayerHand(mockPlayer);
+		assertTrue(capturedOutput().contains(ViewMessages.format("view.card.unknown")));
+		EasyMock.verify(mockCard, mockPlayer);
+	}
 }

--- a/src/test/java/ui/MainTest.java
+++ b/src/test/java/ui/MainTest.java
@@ -3,9 +3,37 @@ package ui;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class MainTest {
 
 	private static final int THREE_TURNS = 3;
+
+	@Test
+	void main_DefaultConstructor_CreatesInstance() {
+		assertNotNull(new Main());
+	}
+
+	@Test
+	void main_InputExhaustedAfterStart_ThrowsIllegalStateException() {
+		InputStream originalIn = System.in;
+		PrintStream originalOut = System.out;
+		try {
+			System.setIn(new ByteArrayInputStream("2\n".getBytes(StandardCharsets.UTF_8)));
+			System.setOut(new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8));
+			assertThrows(IllegalStateException.class, () -> Main.main(new String[]{}));
+		} finally {
+			System.setIn(originalIn);
+			System.setOut(originalOut);
+		}
+	}
 
 	@Test
 	void runGame_gameInactiveImmediately_playsZeroTurns() {


### PR DESCRIPTION
## Summary

Fixes all coverage gaps identified in issue #65 across `TerminalInputReader`, `GameView`, `TerminalDisplayWriter`, `Main`, and `NoAction`.

- **0% methods**: Added simple instantiation tests for `GameView()` and `Main()` constructors, a redirected-stdin test for `Main.main()`, and a no-interaction mock test for `NoAction.execute()`.
- **Missed branches in `readInt` / `readYesNo`**: Added tests that exhaust the scanner input, hitting the `IllegalStateException` throw path.
- **Missed branches in `isWithinRange` / `isValidIndex` / `isValidHandIndex`**: Added tests with negative and below-min inputs to cover the false sides of the range/bounds checks.
- **`addParsedIndex` empty token**: Added a test with a leading comma in card selection input, which produces an empty token after splitting.
- **`parseDisplayNumber` catch branch**: Added a test with a non-numeric token to trigger the `NumberFormatException` catch.
- **`promptCardType` / `GameView.isValidIndex`**: Added a test that submits an invalid index first, forcing the loop and covering the false branch.
- **`formatCard` unknown card**: Added a test with a mocked `Card` where `isName()` always returns false, hitting the fallback `view.card.unknown` return.

## Test plan
- [ ] All existing tests still pass
- [ ] All 14 new tests pass
- [ ] Coverage gaps listed in issue #65 are resolved