### PR TITLE
Integration test/exploding kitten

### DIFF
--- a/docs/bva/integration/ExplodingKitten.md
+++ b/docs/bva/integration/ExplodingKitten.md
@@ -22,15 +22,11 @@ spaces: hasDefuse = {true, false}, isLastPlayerStanding = {true, false}
 
 cases:
 - player draws EK; has Defuse; survives; Defuse discarded; EK reinserted into deck
-- player draws EK; no Defuse; player eliminated; hand cleared to discard pile
+- player draws EK; no Defuse; player eliminated; hand cleared; EK discarded; game ends; winner identified
 - player draws EK; no Defuse; eliminated player never reappears in queue on subsequent turns
-- player draws EK; no Defuse; EK ends up in discard pile, not the deck
-- player draws EK; no Defuse; last player remaining; endGame triggered; winner identified
 
-| test_Name                                               | State of the System                        | Expected output                              | Implemented?       |
-|---------------------------------------------------------|--------------------------------------------|----------------------------------------------|--------------------|
-| explodingKitten_HasDefuse_PlayerSurvivesAndEKReinserted | has Defuse card                            | survives; Defuse discarded; EK back in deck  | :white_check_mark: |
-| explodingKitten_NoDefuse_PlayerEliminated               | no Defuse; 2 players                       | isActive=false; hand cleared                 | :white_check_mark: |
-| explodingKitten_NoDefuse_EliminatedPlayerRemovedFromQueue | no Defuse; 3 players                     | eliminated player never becomes current      | :white_check_mark: |
-| explodingKitten_NoDefuse_EKInDiscardPile                | no Defuse; 2 players                       | EK in discard pile; not in deck              | :white_check_mark: |
-| explodingKitten_LastPlayerRemaining_GameEndsAndWinnerIdentified | no Defuse; last player remaining | game status ENDED; winner is last player     | :white_check_mark: |
+| test_Name                                               | State of the System                        | Expected output                                                          | Implemented?       |
+|---------------------------------------------------------|--------------------------------------------|--------------------------------------------------------------------------|--------------------|
+| explodingKitten_HasDefuse_PlayerSurvivesAndEKReinserted | has Defuse card                            | survives; Defuse discarded; EK back in deck at top                       | :white_check_mark: |
+| explodingKitten_NoDefuse_PlayerEliminatedAndGameEnds    | no Defuse; 2 players                       | eliminated; hand cleared; EK in discard; game ended; winner is player2   | :white_check_mark: |
+| explodingKitten_NoDefuse_EliminatedPlayerRemovedFromQueue | no Defuse; 3 players                     | eliminated player never becomes current on subsequent turns              | :white_check_mark: |

--- a/docs/bva/integration/ExplodingKitten.md
+++ b/docs/bva/integration/ExplodingKitten.md
@@ -1,0 +1,36 @@
+# BVA Analysis for Exploding Kitten draw
+
+## Scope
+
+Integration tests for the **Exploding Kitten** draw flow
+These tests verify the end-to-end behaviour when a player draws an Exploding Kitten card
+
+## Assumptions and Notes
+- Assumes system is already launched
+- Assumes the current player is playing a turn and chooses to draw
+
+## UserStory being verified
+- Player draws a card from the deck
+- If the card is an Exploding Kitten:
+  - If the player has a Defuse card, the Defuse is discarded and the Exploding Kitten is reinserted into the deck at a chosen position — the player survives
+  - If the player has no Defuse card, the player is eliminated: their hand is cleared to the discard pile and the Exploding Kitten is discarded
+  - The eliminated player is removed from the active player queue and never takes another turn
+  - When only one player remains, endGame() is triggered and the last active player is declared the winner
+
+# CardAction under test:
+spaces: hasDefuse = {true, false}, isLastPlayerStanding = {true, false}
+
+cases:
+- player draws EK; has Defuse; survives; Defuse discarded; EK reinserted into deck
+- player draws EK; no Defuse; player eliminated; hand cleared to discard pile
+- player draws EK; no Defuse; eliminated player never reappears in queue on subsequent turns
+- player draws EK; no Defuse; EK ends up in discard pile, not the deck
+- player draws EK; no Defuse; last player remaining; endGame triggered; winner identified
+
+| test_Name                                               | State of the System                        | Expected output                              | Implemented?       |
+|---------------------------------------------------------|--------------------------------------------|----------------------------------------------|--------------------|
+| explodingKitten_HasDefuse_PlayerSurvivesAndEKReinserted | has Defuse card                            | survives; Defuse discarded; EK back in deck  | :white_check_mark: |
+| explodingKitten_NoDefuse_PlayerEliminated               | no Defuse; 2 players                       | isActive=false; hand cleared                 | :white_check_mark: |
+| explodingKitten_NoDefuse_EliminatedPlayerRemovedFromQueue | no Defuse; 3 players                     | eliminated player never becomes current      | :white_check_mark: |
+| explodingKitten_NoDefuse_EKInDiscardPile                | no Defuse; 2 players                       | EK in discard pile; not in deck              | :white_check_mark: |
+| explodingKitten_LastPlayerRemaining_GameEndsAndWinnerIdentified | no Defuse; last player remaining | game status ENDED; winner is last player     | :white_check_mark: |

--- a/src/main/java/domain/model/GameState.java
+++ b/src/main/java/domain/model/GameState.java
@@ -99,6 +99,10 @@ public class GameState {
 		return discardPile.size();
 	}
 
+	public List<Card> getDiscardPile() {
+		return Collections.unmodifiableList(discardPile);
+	}
+
 	public void addCardToCurrentPlayer(Card card) {
 		getCurrentPlayer().addCard(card);
 	}

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -15,7 +15,6 @@ import domain.input.IPlayerInput;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -165,7 +164,6 @@ public class GameController {
 		}
 	}
 
-
 	boolean readyToPlayATurn() {
 		if (!gameState.isActive()) {
 			return false;
@@ -289,8 +287,10 @@ public class GameController {
 	}
 
 	private void useDefuse() {
-		Optional<Card> defuse = gameState.getCurrentPlayer().removeCardOfType(CardType.DEFUSE);
-		defuse.ifPresent(gameState::discardCard);
+		Card defuse = gameState.getCurrentPlayer()
+			.removeCardOfType(CardType.DEFUSE)
+			.orElseThrow();
+		gameState.discardCard(defuse);
 		new DefuseAction(input).execute(gameState);
 	}
 

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -83,13 +83,8 @@ public class GameController {
 		this.gameState = new GameState(players, deck);
 	}
 
-	// method for integration tests to allow us to pass in the state of the deck to avoid random draws from the deck
+	// method for integration tests to allow passing in players and deck state directly
 	void startGame(Deck deck, List<Card> cards, List<Player> players){
-		int numPlayers = input.promptNumPlayers();
-		while (numPlayers < MIN_PLAYERS || numPlayers > MAX_PLAYERS) {
-			display.showMessage(ViewMessages.format("error.num.players"));
-			numPlayers = input.promptNumPlayers();
-		}
 		for (Player player : players) {
 			for (Card card : cards) {
 				player.addCard(card);

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -15,6 +15,7 @@ import domain.input.IPlayerInput;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -138,7 +139,8 @@ public class GameController {
 
 	public void playATurn() {
 		if (!readyToPlayATurn()) {
-			throw new IllegalStateException(ViewMessages.format("error.not.ready.to.play"));}
+			throw new IllegalStateException(ViewMessages.format("error.not.ready.to.play"));
+		}
 		Player currentPlayer = gameState.getCurrentPlayer();
 		display.showCurrentPlayer(currentPlayer);
 		while (hasToPlayATurn()) {
@@ -149,11 +151,23 @@ public class GameController {
 			} else {
 				handleDrawingCards();
 				decrementTurns();
-			}}
-		int turnsForNextPlayer = setTurnsForNextPlayer();
-		resetCurrentPlayerWasAttacked();
-		resetGameState(turnsForNextPlayer);
-		advanceGameToNextPlayer();
+			}
+		}
+		advanceTurnOrTriggerEndGame(currentPlayer);
+	}
+
+	void advanceTurnOrTriggerEndGame(Player currentPlayer) {
+		if (currentPlayer.isActive()) {
+			int turnsForNextPlayer = setTurnsForNextPlayer();
+			resetCurrentPlayerWasAttacked();
+			resetGameState(turnsForNextPlayer);
+			advanceGameToNextPlayer();
+		} else {
+			resetGameState(DEFAULT_NORMAL_TURNS);
+			if (gameState.activePlayerCount() == 1) {
+				endGame();
+			}
+		}
 	}
 
 
@@ -264,15 +278,35 @@ public class GameController {
 	public void drawCard() {
 		Card card = gameState.drawFromDeck();
 		if (card.isType(CardType.EXPLODING_KITTEN)) {
-			gameState.turnState().setPendingAction(card);
-			if (gameState.currentPlayerHasCard(CardType.DEFUSE)) {
-				new DefuseAction(input).execute(gameState);
-			} else {
-				gameState.eliminateCurrentPlayer();
-			}
+			handleExplodingKitten(card);
 		} else {
 			gameState.addCardToCurrentPlayer(card);
 		}
+	}
+
+	private void handleExplodingKitten(Card card) {
+		gameState.turnState().setPendingAction(card);
+		if (gameState.currentPlayerHasCard(CardType.DEFUSE)) {
+			useDefuse();
+		} else {
+			eliminateWithCleanup(card);
+		}
+	}
+
+	private void useDefuse() {
+		Optional<Card> defuse = gameState.getCurrentPlayer().removeCardOfType(CardType.DEFUSE);
+		defuse.ifPresent(gameState::discardCard);
+		new DefuseAction(input).execute(gameState);
+	}
+
+	private void eliminateWithCleanup(Card card) {
+		gameState.discardCard(card);
+		List<Card> handCopy = new ArrayList<>(gameState.getCurrentPlayer().getHand());
+		for (Card handCard : handCopy) {
+			gameState.removeCardFromCurrentPlayer(handCard);
+			gameState.discardCard(handCard);
+		}
+		gameState.eliminateCurrentPlayer();
 	}
 
 	private List<Player> buildPlayers(int numPlayers) {

--- a/src/test/java/ui/ExplodingKittenIntegrationTest.java
+++ b/src/test/java/ui/ExplodingKittenIntegrationTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SuppressWarnings("checkstyle:MethodLength")
 public class ExplodingKittenIntegrationTest {
 
-	private static final int TWO_PLAYERS = 2;
+	private static final int TWO_TURNS = 2;
 
 	private static ComboValidator realComboValidator(IPlayerInput input) {
 		return new ComboValidator(new PlayerInteractionHelper(input, new Random()));
@@ -124,16 +124,16 @@ public class ExplodingKittenIntegrationTest {
 		List<Player> players = new ArrayList<>();
 		Card ekCard = new Card(CardType.EXPLODING_KITTEN, CardName.EXPLODING_KITTEN, new NoAction());
 		Card fillerCard = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
-		Card drawCard = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
+		Card deckFiller = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
 		drawPileCards.add(ekCard);
-		drawPileCards.add(drawCard);
+		drawPileCards.add(deckFiller);
 		playerHandCards.add(fillerCard);
 		players.add(player1);
 		players.add(player2);
 		players.add(player3);
 
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
-		EasyMock.expectLastCall().times(TWO_PLAYERS);
+		EasyMock.expectLastCall().times(TWO_TURNS);
 		EasyMock.expect(input.promptPlayerChoice())
 				.andReturn(PlayerChoice.DONE_PLAYING_CARDS)
 				.andReturn(PlayerChoice.DONE_PLAYING_CARDS);

--- a/src/test/java/ui/ExplodingKittenIntegrationTest.java
+++ b/src/test/java/ui/ExplodingKittenIntegrationTest.java
@@ -1,0 +1,230 @@
+package ui;
+
+import domain.action.NoAction;
+import domain.enums.CardName;
+import domain.enums.CardType;
+import domain.enums.PlayerChoice;
+import domain.factory.ComboValidator;
+import domain.factory.PlayerInteractionHelper;
+import domain.input.IPlayerInput;
+import domain.model.Card;
+import domain.model.Deck;
+import domain.model.Player;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("checkstyle:MethodLength")
+public class ExplodingKittenIntegrationTest {
+
+	private static final int TWO_PLAYERS = 2;
+	private static final int THREE_PLAYERS = 3;
+
+	private static ComboValidator realComboValidator(IPlayerInput input) {
+		return new ComboValidator(new PlayerInteractionHelper(input, new Random()));
+	}
+
+	@Test
+	void explodingKitten_HasDefuse_PlayerSurvivesAndEKReinserted() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+		Player player1 = new Player("P1", "Player1");
+		Player player2 = new Player("P2", "Player2");
+		List<Card> playerHandCards = new ArrayList<>();
+		List<Card> drawPileCards = new ArrayList<>();
+		List<Player> players = new ArrayList<>();
+		Card ekCard = new Card(CardType.EXPLODING_KITTEN, CardName.EXPLODING_KITTEN, new NoAction());
+		Card defuseCard = new Card(CardType.DEFUSE, CardName.DEFUSE, new NoAction());
+		Card fillerCard = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
+		drawPileCards.add(ekCard);
+		playerHandCards.add(defuseCard);
+		playerHandCards.add(fillerCard);
+		players.add(player1);
+		players.add(player2);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
+		display.showCurrentPlayer(EasyMock.isA(Player.class));
+		EasyMock.expectLastCall().once();
+		EasyMock.expect(input.promptPlayerChoice()).andReturn(PlayerChoice.DONE_PLAYING_CARDS);
+		EasyMock.expect(input.promptInsertPosition(0)).andReturn(0);
+
+		EasyMock.replay(display, input);
+
+		GameController gc = new GameController(display, input, realComboValidator(input));
+		Deck deck = new Deck(drawPileCards);
+		gc.startGame(deck, playerHandCards, players);
+		Player firstPlayer = gc.gameState().getCurrentPlayer();
+		gc.playATurn();
+
+		assertTrue(firstPlayer.isActive());
+		assertNotEquals(firstPlayer, gc.gameState().getCurrentPlayer());
+		assertEquals(1, gc.gameState().getDeckSize());
+		assertEquals(1, gc.gameState().getDiscardPileSize());
+		assertTrue(gc.gameState().getDiscardPile().stream().anyMatch(c -> c.isType(CardType.DEFUSE)));
+		assertTrue(gc.gameState().peekTopOfDeck(1).get(0).isType(CardType.EXPLODING_KITTEN));
+
+		EasyMock.verify(display, input);
+	}
+
+	@Test
+	void explodingKitten_NoDefuse_PlayerEliminated() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+		Player player1 = new Player("P1", "Player1");
+		Player player2 = new Player("P2", "Player2");
+		List<Card> playerHandCards = new ArrayList<>();
+		List<Card> drawPileCards = new ArrayList<>();
+		List<Player> players = new ArrayList<>();
+		Card ekCard = new Card(CardType.EXPLODING_KITTEN, CardName.EXPLODING_KITTEN, new NoAction());
+		Card fillerCard = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
+		drawPileCards.add(ekCard);
+		playerHandCards.add(fillerCard);
+		players.add(player1);
+		players.add(player2);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
+		display.showCurrentPlayer(EasyMock.isA(Player.class));
+		EasyMock.expectLastCall().once();
+		EasyMock.expect(input.promptPlayerChoice()).andReturn(PlayerChoice.DONE_PLAYING_CARDS);
+		display.showWinner(player2);
+		EasyMock.expect(input.promptRestart()).andReturn(false);
+
+		EasyMock.replay(display, input);
+
+		GameController gc = new GameController(display, input, realComboValidator(input));
+		Deck deck = new Deck(drawPileCards);
+		gc.startGame(deck, playerHandCards, players);
+		Player firstPlayer = gc.gameState().getCurrentPlayer();
+		gc.playATurn();
+
+		assertFalse(firstPlayer.isActive());
+		assertFalse(gc.isGameActive());
+		assertTrue(firstPlayer.getHand().isEmpty());
+
+		EasyMock.verify(display, input);
+	}
+
+	@Test
+	void explodingKitten_NoDefuse_EliminatedPlayerRemovedFromQueue() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+		Player player1 = new Player("P1", "Player1");
+		Player player2 = new Player("P2", "Player2");
+		Player player3 = new Player("P3", "Player3");
+		List<Card> playerHandCards = new ArrayList<>();
+		List<Card> drawPileCards = new ArrayList<>();
+		List<Player> players = new ArrayList<>();
+		Card ekCard = new Card(CardType.EXPLODING_KITTEN, CardName.EXPLODING_KITTEN, new NoAction());
+		Card fillerCard = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
+		Card drawCard = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
+		drawPileCards.add(ekCard);
+		drawPileCards.add(drawCard);
+		playerHandCards.add(fillerCard);
+		players.add(player1);
+		players.add(player2);
+		players.add(player3);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(THREE_PLAYERS);
+		display.showCurrentPlayer(EasyMock.isA(Player.class));
+		EasyMock.expectLastCall().times(TWO_PLAYERS);
+		EasyMock.expect(input.promptPlayerChoice())
+				.andReturn(PlayerChoice.DONE_PLAYING_CARDS)
+				.andReturn(PlayerChoice.DONE_PLAYING_CARDS);
+
+		EasyMock.replay(display, input);
+
+		GameController gc = new GameController(display, input, realComboValidator(input));
+		Deck deck = new Deck(drawPileCards);
+		gc.startGame(deck, playerHandCards, players);
+		Player firstPlayer = gc.gameState().getCurrentPlayer();
+
+		gc.playATurn();
+		assertFalse(firstPlayer.isActive());
+		assertNotEquals(firstPlayer, gc.gameState().getCurrentPlayer());
+
+		gc.playATurn();
+		assertNotEquals(firstPlayer, gc.gameState().getCurrentPlayer());
+
+		EasyMock.verify(display, input);
+	}
+
+	@Test
+	void explodingKitten_NoDefuse_EKInDiscardPile() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+		Player player1 = new Player("P1", "Player1");
+		Player player2 = new Player("P2", "Player2");
+		List<Card> playerHandCards = new ArrayList<>();
+		List<Card> drawPileCards = new ArrayList<>();
+		List<Player> players = new ArrayList<>();
+		Card ekCard = new Card(CardType.EXPLODING_KITTEN, CardName.EXPLODING_KITTEN, new NoAction());
+		Card fillerCard = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
+		drawPileCards.add(ekCard);
+		playerHandCards.add(fillerCard);
+		players.add(player1);
+		players.add(player2);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
+		display.showCurrentPlayer(EasyMock.isA(Player.class));
+		EasyMock.expectLastCall().once();
+		EasyMock.expect(input.promptPlayerChoice()).andReturn(PlayerChoice.DONE_PLAYING_CARDS);
+		display.showWinner(player2);
+		EasyMock.expect(input.promptRestart()).andReturn(false);
+
+		EasyMock.replay(display, input);
+
+		GameController gc = new GameController(display, input, realComboValidator(input));
+		Deck deck = new Deck(drawPileCards);
+		gc.startGame(deck, playerHandCards, players);
+		gc.playATurn();
+
+		assertEquals(0, gc.gameState().getDeckSize());
+		assertTrue(gc.gameState().getDiscardPile().stream().anyMatch(c -> c.isType(CardType.EXPLODING_KITTEN)));
+
+		EasyMock.verify(display, input);
+	}
+
+	@Test
+	void explodingKitten_LastPlayerRemaining_GameEndsAndWinnerIdentified() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+		Player player1 = new Player("P1", "Player1");
+		Player player2 = new Player("P2", "Player2");
+		List<Card> playerHandCards = new ArrayList<>();
+		List<Card> drawPileCards = new ArrayList<>();
+		List<Player> players = new ArrayList<>();
+		Card ekCard = new Card(CardType.EXPLODING_KITTEN, CardName.EXPLODING_KITTEN, new NoAction());
+		Card fillerCard = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
+		drawPileCards.add(ekCard);
+		playerHandCards.add(fillerCard);
+		players.add(player1);
+		players.add(player2);
+
+		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
+		display.showCurrentPlayer(EasyMock.isA(Player.class));
+		EasyMock.expectLastCall().once();
+		EasyMock.expect(input.promptPlayerChoice()).andReturn(PlayerChoice.DONE_PLAYING_CARDS);
+		display.showWinner(player2);
+		EasyMock.expect(input.promptRestart()).andReturn(false);
+
+		EasyMock.replay(display, input);
+
+		GameController gc = new GameController(display, input, realComboValidator(input));
+		Deck deck = new Deck(drawPileCards);
+		gc.startGame(deck, playerHandCards, players);
+		gc.playATurn();
+
+		assertFalse(gc.isGameActive());
+		assertEquals(player2, gc.gameState().getCurrentPlayer());
+
+		EasyMock.verify(display, input);
+	}
+}

--- a/src/test/java/ui/ExplodingKittenIntegrationTest.java
+++ b/src/test/java/ui/ExplodingKittenIntegrationTest.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ExplodingKittenIntegrationTest {
 
 	private static final int TWO_PLAYERS = 2;
-	private static final int THREE_PLAYERS = 3;
 
 	private static ComboValidator realComboValidator(IPlayerInput input) {
 		return new ComboValidator(new PlayerInteractionHelper(input, new Random()));
@@ -50,7 +49,6 @@ public class ExplodingKittenIntegrationTest {
 		players.add(player1);
 		players.add(player2);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice()).andReturn(PlayerChoice.DONE_PLAYING_CARDS);
@@ -75,7 +73,7 @@ public class ExplodingKittenIntegrationTest {
 	}
 
 	@Test
-	void explodingKitten_NoDefuse_PlayerEliminated() {
+	void explodingKitten_NoDefuse_PlayerEliminatedAndGameEnds() {
 		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
 		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
 		Player player1 = new Player("P1", "Player1");
@@ -90,7 +88,6 @@ public class ExplodingKittenIntegrationTest {
 		players.add(player1);
 		players.add(player2);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice()).andReturn(PlayerChoice.DONE_PLAYING_CARDS);
@@ -106,8 +103,11 @@ public class ExplodingKittenIntegrationTest {
 		gc.playATurn();
 
 		assertFalse(firstPlayer.isActive());
-		assertFalse(gc.isGameActive());
 		assertTrue(firstPlayer.getHand().isEmpty());
+		assertFalse(gc.isGameActive());
+		assertEquals(0, gc.gameState().getDeckSize());
+		assertTrue(gc.gameState().getDiscardPile().stream().anyMatch(c -> c.isType(CardType.EXPLODING_KITTEN)));
+		assertEquals(player2, gc.gameState().getCurrentPlayer());
 
 		EasyMock.verify(display, input);
 	}
@@ -132,7 +132,6 @@ public class ExplodingKittenIntegrationTest {
 		players.add(player2);
 		players.add(player3);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(THREE_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().times(TWO_PLAYERS);
 		EasyMock.expect(input.promptPlayerChoice())
@@ -152,78 +151,6 @@ public class ExplodingKittenIntegrationTest {
 
 		gc.playATurn();
 		assertNotEquals(firstPlayer, gc.gameState().getCurrentPlayer());
-
-		EasyMock.verify(display, input);
-	}
-
-	@Test
-	void explodingKitten_NoDefuse_EKInDiscardPile() {
-		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
-		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
-		Player player1 = new Player("P1", "Player1");
-		Player player2 = new Player("P2", "Player2");
-		List<Card> playerHandCards = new ArrayList<>();
-		List<Card> drawPileCards = new ArrayList<>();
-		List<Player> players = new ArrayList<>();
-		Card ekCard = new Card(CardType.EXPLODING_KITTEN, CardName.EXPLODING_KITTEN, new NoAction());
-		Card fillerCard = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
-		drawPileCards.add(ekCard);
-		playerHandCards.add(fillerCard);
-		players.add(player1);
-		players.add(player2);
-
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
-		display.showCurrentPlayer(EasyMock.isA(Player.class));
-		EasyMock.expectLastCall().once();
-		EasyMock.expect(input.promptPlayerChoice()).andReturn(PlayerChoice.DONE_PLAYING_CARDS);
-		display.showWinner(player2);
-		EasyMock.expect(input.promptRestart()).andReturn(false);
-
-		EasyMock.replay(display, input);
-
-		GameController gc = new GameController(display, input, realComboValidator(input));
-		Deck deck = new Deck(drawPileCards);
-		gc.startGame(deck, playerHandCards, players);
-		gc.playATurn();
-
-		assertEquals(0, gc.gameState().getDeckSize());
-		assertTrue(gc.gameState().getDiscardPile().stream().anyMatch(c -> c.isType(CardType.EXPLODING_KITTEN)));
-
-		EasyMock.verify(display, input);
-	}
-
-	@Test
-	void explodingKitten_LastPlayerRemaining_GameEndsAndWinnerIdentified() {
-		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
-		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
-		Player player1 = new Player("P1", "Player1");
-		Player player2 = new Player("P2", "Player2");
-		List<Card> playerHandCards = new ArrayList<>();
-		List<Card> drawPileCards = new ArrayList<>();
-		List<Player> players = new ArrayList<>();
-		Card ekCard = new Card(CardType.EXPLODING_KITTEN, CardName.EXPLODING_KITTEN, new NoAction());
-		Card fillerCard = new Card(CardType.SHUFFLE, CardName.SHUFFLE, new NoAction());
-		drawPileCards.add(ekCard);
-		playerHandCards.add(fillerCard);
-		players.add(player1);
-		players.add(player2);
-
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
-		display.showCurrentPlayer(EasyMock.isA(Player.class));
-		EasyMock.expectLastCall().once();
-		EasyMock.expect(input.promptPlayerChoice()).andReturn(PlayerChoice.DONE_PLAYING_CARDS);
-		display.showWinner(player2);
-		EasyMock.expect(input.promptRestart()).andReturn(false);
-
-		EasyMock.replay(display, input);
-
-		GameController gc = new GameController(display, input, realComboValidator(input));
-		Deck deck = new Deck(drawPileCards);
-		gc.startGame(deck, playerHandCards, players);
-		gc.playATurn();
-
-		assertFalse(gc.isGameActive());
-		assertEquals(player2, gc.gameState().getCurrentPlayer());
 
 		EasyMock.verify(display, input);
 	}

--- a/src/test/java/ui/FavorIntegrationTest.java
+++ b/src/test/java/ui/FavorIntegrationTest.java
@@ -60,7 +60,6 @@ public class FavorIntegrationTest {
 		players.add(player1);
 		players.add(player2);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice())
@@ -120,7 +119,6 @@ public class FavorIntegrationTest {
 		players.add(player2);
 		players.add(player3);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(THREE_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().times(TWO_TURNS);
 		EasyMock.expect(input.promptPlayerChoice())
@@ -188,7 +186,6 @@ public class FavorIntegrationTest {
 		players.add(player1);
 		players.add(player2);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice())

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -1058,7 +1059,7 @@ public class GameControllerTest {
 		turnState.reset(0);
 		EasyMock.expect(mockGameState.isActive()).andReturn(true);
 		EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(mockPlayer).anyTimes();
-		EasyMock.expect(mockPlayer.isActive()).andReturn(true);
+		EasyMock.expect(mockPlayer.isActive()).andReturn(true).anyTimes();
 		EasyMock.expect(mockGameState.turnState()).andReturn(turnState).anyTimes();
 		display.showCurrentPlayer(mockPlayer);
 		EasyMock.expectLastCall().once();
@@ -1084,7 +1085,7 @@ public class GameControllerTest {
 		List<Card> cards = List.of(card);
 		EasyMock.expect(mockGameState.isActive()).andReturn(true);
 		EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(mockPlayer).anyTimes();
-		EasyMock.expect(mockPlayer.isActive()).andReturn(true);
+		EasyMock.expect(mockPlayer.isActive()).andReturn(true).anyTimes();
 		EasyMock.expect(mockGameState.turnState()).andReturn(turnState).anyTimes();
 		display.showCurrentPlayer(mockPlayer);
 		EasyMock.expectLastCall().once();
@@ -1126,7 +1127,7 @@ public class GameControllerTest {
 		TurnState turnState = new TurnState();
 		EasyMock.expect(mockGameState.isActive()).andReturn(true);
 		EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(mockPlayer).anyTimes();
-		EasyMock.expect(mockPlayer.isActive()).andReturn(true);
+		EasyMock.expect(mockPlayer.isActive()).andReturn(true).anyTimes();
 		EasyMock.expect(mockGameState.turnState()).andReturn(turnState).anyTimes();
 		display.showCurrentPlayer(mockPlayer);
 		EasyMock.expectLastCall().once();
@@ -1186,19 +1187,24 @@ public class GameControllerTest {
 		IPlayerInput mockInput = EasyMock.createMock(IPlayerInput.class);
 		ComboValidator mockComboValidator = EasyMock.createMock(ComboValidator.class);
 		TurnState mockTurnState = EasyMock.createMock(TurnState.class);
+		Player mockPlayer = EasyMock.createMock(Player.class);
 		Card mockCard = EasyMock.createMock(Card.class);
+		Card defuseCard = new Card(CardType.DEFUSE, CardName.DEFUSE, new NoAction());
 		GameState mockGameState = EasyMock.createMock(GameState.class);
 		EasyMock.expect(mockGameState.drawFromDeck()).andReturn(mockCard);
 		EasyMock.expect(mockCard.isType(CardType.EXPLODING_KITTEN)).andReturn(true);
 		EasyMock.expect(mockGameState.turnState()).andReturn(mockTurnState);
 		mockTurnState.setPendingAction(mockCard);
 		EasyMock.expect(mockGameState.currentPlayerHasCard(CardType.DEFUSE)).andReturn(true);
+		EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(mockPlayer);
+		EasyMock.expect(mockPlayer.removeCardOfType(CardType.DEFUSE)).andReturn(Optional.of(defuseCard));
+		mockGameState.discardCard(defuseCard);
 		EasyMock.expect(mockGameState.getDeckSize()).andReturn(1);
 		EasyMock.expect(mockInput.promptInsertPosition(1)).andReturn(0);
 		mockGameState.insertPendingCardAt(0);
-		EasyMock.replay(mockGameState, mockTurnState, mockCard, mockInput, mockDisplay);
+		EasyMock.replay(mockGameState, mockTurnState, mockCard, mockPlayer, mockInput, mockDisplay);
 		new GameController(mockGameState, mockDisplay, mockInput, mockComboValidator).drawCard();
-		EasyMock.verify(mockGameState, mockTurnState, mockCard, mockInput, mockDisplay);
+		EasyMock.verify(mockGameState, mockTurnState, mockCard, mockPlayer, mockInput, mockDisplay);
 	}
 
 	@Test
@@ -1207,17 +1213,24 @@ public class GameControllerTest {
 		IPlayerInput mockInput = EasyMock.createMock(IPlayerInput.class);
 		ComboValidator mockComboValidator = EasyMock.createMock(ComboValidator.class);
 		TurnState mockTurnState = EasyMock.createMock(TurnState.class);
+		Player mockPlayer = EasyMock.createMock(Player.class);
 		Card mockCard = EasyMock.createMock(Card.class);
+		Card handCard = new Card(CardType.SKIP, CardName.SKIP, new NoAction());
 		GameState mockGameState = EasyMock.createMock(GameState.class);
 		EasyMock.expect(mockGameState.drawFromDeck()).andReturn(mockCard);
 		EasyMock.expect(mockCard.isType(CardType.EXPLODING_KITTEN)).andReturn(true);
 		EasyMock.expect(mockGameState.turnState()).andReturn(mockTurnState);
 		mockTurnState.setPendingAction(mockCard);
 		EasyMock.expect(mockGameState.currentPlayerHasCard(CardType.DEFUSE)).andReturn(false);
+		mockGameState.discardCard(mockCard);
+		EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(mockPlayer);
+		EasyMock.expect(mockPlayer.getHand()).andReturn(List.of(handCard));
+		mockGameState.removeCardFromCurrentPlayer(handCard);
+		mockGameState.discardCard(handCard);
 		mockGameState.eliminateCurrentPlayer();
-		EasyMock.replay(mockGameState, mockTurnState, mockCard, mockInput, mockDisplay);
+		EasyMock.replay(mockGameState, mockTurnState, mockCard, mockPlayer, mockInput, mockDisplay);
 		new GameController(mockGameState, mockDisplay, mockInput, mockComboValidator).drawCard();
-		EasyMock.verify(mockGameState, mockTurnState, mockCard, mockInput, mockDisplay);
+		EasyMock.verify(mockGameState, mockTurnState, mockCard, mockPlayer, mockInput, mockDisplay);
 	}
 
 }

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -1000,20 +1000,23 @@ public class GameControllerTest {
 		ComboValidator comboValidator = EasyMock.createMock(ComboValidator.class);
 		Player mockPlayer = EasyMock.createMock(Player.class);
 		GameState mockGameState = EasyMock.createMock(GameState.class);
-		TurnState turnState = new TurnState();
-		EasyMock.expect(mockGameState.turnState()).andReturn(turnState).anyTimes();
+		TurnState mockTurnState = EasyMock.createMock(TurnState.class);
+		EasyMock.expect(mockGameState.turnState()).andReturn(mockTurnState).anyTimes();
 		EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(mockPlayer).anyTimes();
 		EasyMock.expect(mockPlayer.isActive()).andReturn(true);
+		EasyMock.expect(mockTurnState.isAttacking()).andReturn(false);
+		mockTurnState.reset(1);
+		EasyMock.expectLastCall().once();
 		mockPlayer.resetWasAttacked();
 		EasyMock.expectLastCall().once();
 		mockGameState.advancePlayer();
 		EasyMock.expectLastCall().once();
-		EasyMock.replay(mockGameState, mockPlayer, display, input, comboValidator);
+		EasyMock.replay(mockGameState, mockTurnState, mockPlayer, display, input, comboValidator);
 
 		GameController gc = new GameController(mockGameState, display, input, comboValidator);
 		gc.advanceTurnOrTriggerEndGame(mockPlayer);
 
-		EasyMock.verify(mockGameState, mockPlayer, display, input, comboValidator);
+		EasyMock.verify(mockGameState, mockTurnState, mockPlayer, display, input, comboValidator);
 	}
 
 	@Test

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -1010,7 +1010,8 @@ public class GameControllerTest {
 		EasyMock.expectLastCall().once();
 		EasyMock.replay(mockGameState, mockPlayer, display, input, comboValidator);
 
-		new GameController(mockGameState, display, input, comboValidator).advanceTurnOrTriggerEndGame(mockPlayer);
+		GameController gc = new GameController(mockGameState, display, input, comboValidator);
+		gc.advanceTurnOrTriggerEndGame(mockPlayer);
 
 		EasyMock.verify(mockGameState, mockPlayer, display, input, comboValidator);
 	}
@@ -1052,7 +1053,8 @@ public class GameControllerTest {
 		EasyMock.expect(input.promptRestart()).andReturn(false);
 		EasyMock.replay(mockGameState, mockTurnState, mockPlayer, mockWinner, display, input, comboValidator);
 
-		new GameController(mockGameState, display, input, comboValidator).advanceTurnOrTriggerEndGame(mockPlayer);
+		GameController gc = new GameController(mockGameState, display, input, comboValidator);
+		gc.advanceTurnOrTriggerEndGame(mockPlayer);
 
 		EasyMock.verify(mockGameState, mockTurnState, mockPlayer, mockWinner, display, input, comboValidator);
 	}

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -994,6 +994,70 @@ public class GameControllerTest {
 	}
 
 	@Test
+	void advanceTurnOrTriggerEndGame_PlayerIsActive_AdvancesNormally() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+		ComboValidator comboValidator = EasyMock.createMock(ComboValidator.class);
+		Player mockPlayer = EasyMock.createMock(Player.class);
+		GameState mockGameState = EasyMock.createMock(GameState.class);
+		TurnState turnState = new TurnState();
+		EasyMock.expect(mockGameState.turnState()).andReturn(turnState).anyTimes();
+		EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(mockPlayer).anyTimes();
+		EasyMock.expect(mockPlayer.isActive()).andReturn(true);
+		mockPlayer.resetWasAttacked();
+		EasyMock.expectLastCall().once();
+		mockGameState.advancePlayer();
+		EasyMock.expectLastCall().once();
+		EasyMock.replay(mockGameState, mockPlayer, display, input, comboValidator);
+
+		new GameController(mockGameState, display, input, comboValidator).advanceTurnOrTriggerEndGame(mockPlayer);
+
+		EasyMock.verify(mockGameState, mockPlayer, display, input, comboValidator);
+	}
+
+	@Test
+	void advanceTurnOrTriggerEndGame_PlayerIsEliminated_MultiplePlayersRemain_ResetsState() {
+		Player mockPlayer = EasyMock.createMock(Player.class);
+		GameState mockGameState = EasyMock.createMock(GameState.class);
+		TurnState mockTurnState = EasyMock.createMock(TurnState.class);
+		EasyMock.expect(mockGameState.turnState()).andReturn(mockTurnState).anyTimes();
+		EasyMock.expect(mockPlayer.isActive()).andReturn(false);
+		mockTurnState.reset(1);
+		EasyMock.expectLastCall().once();
+		EasyMock.expect(mockGameState.activePlayerCount()).andReturn(2);
+		EasyMock.replay(mockGameState, mockTurnState, mockPlayer);
+
+		createGameController(mockGameState).advanceTurnOrTriggerEndGame(mockPlayer);
+
+		EasyMock.verify(mockGameState, mockTurnState, mockPlayer);
+	}
+
+	@Test
+	void advanceTurnOrTriggerEndGame_PlayerIsEliminated_LastPlayerRemaining_TriggersEndGame() {
+		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
+		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
+		ComboValidator comboValidator = EasyMock.createMock(ComboValidator.class);
+		Player mockPlayer = EasyMock.createMock(Player.class);
+		Player mockWinner = EasyMock.createMock(Player.class);
+		GameState mockGameState = EasyMock.createMock(GameState.class);
+		TurnState mockTurnState = EasyMock.createMock(TurnState.class);
+		EasyMock.expect(mockGameState.turnState()).andReturn(mockTurnState).anyTimes();
+		EasyMock.expect(mockPlayer.isActive()).andReturn(false);
+		mockTurnState.reset(1);
+		EasyMock.expectLastCall().once();
+		EasyMock.expect(mockGameState.activePlayerCount()).andReturn(1);
+		mockGameState.endGame();
+		EasyMock.expect(mockGameState.getCurrentPlayer()).andReturn(mockWinner);
+		display.showWinner(mockWinner);
+		EasyMock.expect(input.promptRestart()).andReturn(false);
+		EasyMock.replay(mockGameState, mockTurnState, mockPlayer, mockWinner, display, input, comboValidator);
+
+		new GameController(mockGameState, display, input, comboValidator).advanceTurnOrTriggerEndGame(mockPlayer);
+
+		EasyMock.verify(mockGameState, mockTurnState, mockPlayer, mockWinner, display, input, comboValidator);
+	}
+
+	@Test
 	void readyToPlayATurn_gameStateNotActive_ReturnsFalse() {
 		GameState mockGameState = EasyMock.createMock(GameState.class);
 		EasyMock.expect(mockGameState.isActive()).andReturn(false);

--- a/src/test/java/ui/ThreeCardIntegrationTest.java
+++ b/src/test/java/ui/ThreeCardIntegrationTest.java
@@ -67,7 +67,6 @@ public class ThreeCardIntegrationTest {
 		drawPileCards.add(shuffleCard2);
 		drawPileCards.add(shuffleCard3);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice())
@@ -135,7 +134,6 @@ public class ThreeCardIntegrationTest {
 		drawPileCards.add(shuffleCard2);
 		drawPileCards.add(shuffleCard3);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice())
@@ -203,7 +201,6 @@ public class ThreeCardIntegrationTest {
 		drawPileCards.add(shuffleCard2);
 		drawPileCards.add(shuffleCard3);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice())
@@ -270,7 +267,6 @@ public class ThreeCardIntegrationTest {
 		drawPileCards.add(shuffleCard3);
 
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice())

--- a/src/test/java/ui/TwoCardIntegrationTest.java
+++ b/src/test/java/ui/TwoCardIntegrationTest.java
@@ -65,7 +65,6 @@ public class TwoCardIntegrationTest {
 		drawPileCards.add(shuffleCard2);
 		drawPileCards.add(shuffleCard3);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice())
@@ -132,7 +131,6 @@ public class TwoCardIntegrationTest {
 		drawPileCards.add(shuffleCard3);
 
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice())
@@ -200,7 +198,6 @@ public class TwoCardIntegrationTest {
 		drawPileCards.add(shuffleCard2);
 		drawPileCards.add(shuffleCard3);
 
-		EasyMock.expect(input.promptNumPlayers()).andReturn(TWO_PLAYERS);
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice())


### PR DESCRIPTION
Integration tests for the Exploding Kitten draw flow.

## Summary
- Fixes `GameController.drawCard()` to discard the Defuse on use, discard the EK and clear the eliminated player's hand when there is no Defuse
- Fixes `GameController.playATurn()` to preserve correct turn order after elimination (eliminated player was previously causing the next player to be skipped) and auto-trigger `endGame()` when only one player remains
- Adds `GameState.getDiscardPile()` accessor for test assertions
- Removes dead `promptNumPlayers()` call from the 3-arg `startGame` overload
- Adds 3 integration tests covering: defuse survival + EK reinsertion, full elimination flow (hand cleared, EK discarded, game ends, winner identified), and eliminated player never reappearing in the queue
- Adds 3 unit tests for the new `advanceTurnOrTriggerEndGame` helper covering both the active-player and eliminated-player branches
- Adds BVA analysis doc for the Exploding Kitten draw scenarios

## Test plan
- [ ] All existing tests still pass
- [ ] `explodingKitten_HasDefuse_PlayerSurvivesAndEKReinserted` — player survives, Defuse in discard pile, EK back at top of deck
- [ ] `explodingKitten_NoDefuse_PlayerEliminatedAndGameEnds` — player eliminated, hand cleared, EK in discard pile, game ended, winner is last active player
- [ ] `explodingKitten_NoDefuse_EliminatedPlayerRemovedFromQueue` — eliminated player never becomes current player on subsequent turns