### PR TITLE
feat: show elimination message when player draws Exploding Kitten

### DIFF
--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -307,11 +307,13 @@ public class GameController {
 
 	private void eliminateWithCleanup(Card card) {
 		gameState.discardCard(card);
-		List<Card> handCopy = new ArrayList<>(gameState.getCurrentPlayer().getHand());
+		Player current = gameState.getCurrentPlayer();
+		List<Card> handCopy = new ArrayList<>(current.getHand());
 		for (Card handCard : handCopy) {
 			gameState.removeCardFromCurrentPlayer(handCard);
 			gameState.discardCard(handCard);
 		}
+		display.showEliminated(current);
 		gameState.eliminateCurrentPlayer();
 	}
 

--- a/src/main/java/ui/GameView.java
+++ b/src/main/java/ui/GameView.java
@@ -56,6 +56,10 @@ public class GameView implements IGameDisplay, IPlayerInput {
 		display.showCurrentPlayer(player);
 	}
 
+	public void showEliminated(Player player) {
+		display.showEliminated(player);
+	}
+
 	public List<Card> promptCardSelection(Player player) {
 		return input.promptCardSelection(player);
 	}

--- a/src/main/java/ui/IGameDisplay.java
+++ b/src/main/java/ui/IGameDisplay.java
@@ -13,4 +13,6 @@ public interface IGameDisplay {
 	void showWinner(Player player);
 
 	void showCurrentPlayer(Player player);
+
+	void showEliminated(Player player);
 }

--- a/src/main/java/ui/TerminalDisplayWriter.java
+++ b/src/main/java/ui/TerminalDisplayWriter.java
@@ -89,6 +89,10 @@ final class TerminalDisplayWriter {
 		output.println(ViewMessages.format("view.current.player.turn", player.getName()));
 	}
 
+	void showEliminated(Player player) {
+		output.println(ViewMessages.format("view.player.eliminated", player.getName()));
+	}
+
 	void printNumberedPlayers(List<Player> candidates) {
 		for (int index = 0; index < candidates.size(); index++) {
 			int displayNumber = index + 1;

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -68,3 +68,4 @@ card.type.SEE_THE_FUTURE=See the Future
 card.type.FAVOR=Favor
 card.type.NOPE=Nope
 card.type.CAT_CARD=Cat Card
+view.player.eliminated={0} drew an Exploding Kitten and has been eliminated!

--- a/src/main/resources/labels_de.properties
+++ b/src/main/resources/labels_de.properties
@@ -69,3 +69,4 @@ card.type.SEE_THE_FUTURE=Zukunft sehen
 card.type.FAVOR=Gefallen
 card.type.NOPE=Nein
 card.type.CAT_CARD=Katzenkarte
+view.player.eliminated={0} hat eine Exploding Kitten gezogen und wurde eliminiert!

--- a/src/main/resources/labels_es.properties
+++ b/src/main/resources/labels_es.properties
@@ -69,3 +69,4 @@ card.type.SEE_THE_FUTURE=Ver el Futuro
 card.type.FAVOR=Favor
 card.type.NOPE=No
 card.type.CAT_CARD=Carta de Gato
+view.player.eliminated={0} sacó un Gatito Explosivo y ha sido eliminado!

--- a/src/main/resources/labels_fr.properties
+++ b/src/main/resources/labels_fr.properties
@@ -69,3 +69,4 @@ card.type.SEE_THE_FUTURE=Voir le Futur
 card.type.FAVOR=Faveur
 card.type.NOPE=Non
 card.type.CAT_CARD=Carte Chat
+view.player.eliminated={0} a tiré un Chaton Explosif et a été éliminé !

--- a/src/test/java/ui/ExplodingKittenIntegrationTest.java
+++ b/src/test/java/ui/ExplodingKittenIntegrationTest.java
@@ -91,6 +91,7 @@ public class ExplodingKittenIntegrationTest {
 		display.showCurrentPlayer(EasyMock.isA(Player.class));
 		EasyMock.expectLastCall().once();
 		EasyMock.expect(input.promptPlayerChoice()).andReturn(PlayerChoice.DONE_PLAYING_CARDS);
+		display.showEliminated(EasyMock.isA(Player.class));
 		display.showWinner(player2);
 		EasyMock.expect(input.promptRestart()).andReturn(false);
 
@@ -137,6 +138,7 @@ public class ExplodingKittenIntegrationTest {
 		EasyMock.expect(input.promptPlayerChoice())
 				.andReturn(PlayerChoice.DONE_PLAYING_CARDS)
 				.andReturn(PlayerChoice.DONE_PLAYING_CARDS);
+		display.showEliminated(EasyMock.isA(Player.class));
 
 		EasyMock.replay(display, input);
 

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -1469,6 +1469,7 @@ public class GameControllerTest {
 		EasyMock.expect(mockPlayer.getHand()).andReturn(List.of(handCard));
 		mockGameState.removeCardFromCurrentPlayer(handCard);
 		mockGameState.discardCard(handCard);
+		mockDisplay.showEliminated(mockPlayer);
 		mockGameState.eliminateCurrentPlayer();
 		EasyMock.replay(mockGameState, mockTurnState, mockCard, mockPlayer, mockInput, mockDisplay);
 		new GameController(mockGameState, mockDisplay, mockInput, mockComboValidator).drawCard();

--- a/src/test/java/ui/GameViewTest.java
+++ b/src/test/java/ui/GameViewTest.java
@@ -379,6 +379,16 @@ public class GameViewTest {
 	}
 
 	@Test
+	void showEliminated_NamedPlayer_PrintsEliminationMessage() {
+		Player mockPlayer = mockNamedPlayer("Alice");
+		createView("").showEliminated(mockPlayer);
+		String output = capturedOutput();
+		assertTrue(output.contains("Alice"));
+		assertTrue(output.contains("eliminated"));
+		EasyMock.verify(mockPlayer);
+	}
+
+	@Test
 	void showPlayerHand_UnknownCard_PrintsUnknown() {
 		Card mockCard = EasyMock.createMock(Card.class);
 		EasyMock.expect(mockCard.isName(EasyMock.anyObject(CardName.class))).andReturn(false).anyTimes();


### PR DESCRIPTION
## Summary

- Closes #90
- Added `showEliminated(Player)` to `IGameDisplay`, `GameView`, and `TerminalDisplayWriter` to display an elimination message when a player draws an Exploding Kitten
- `GameController.eliminateWithCleanup` now calls `display.showEliminated` before removing the player, so the player's name is still accessible at call time
- Localized the elimination message across all four supported locales (en, de, es, fr)

## Test plan

- [x] `GameControllerTest` — verifies `showEliminated` is called during elimination
- [x] `GameViewTest` — verifies delegation to the underlying display
- [x] `ExplodingKittenIntegrationTest` — end-to-end check that elimination flow completes
- [x] Manually ran the game, drew an Exploding Kitten, and confirmed the expected elimination message displayed correctly
<img width="647" height="87" alt="Screenshot 2026-06-07 at 4 26 58 PM" src="https://github.com/user-attachments/assets/f72b16df-175b-4664-ae40-1015ae4ed262" />

