### PR TITLE
Bugfix/nope

### DIFF
--- a/src/main/java/domain/factory/ComboValidator.java
+++ b/src/main/java/domain/factory/ComboValidator.java
@@ -30,7 +30,8 @@ public class ComboValidator {
 	private boolean isValidSingle(Card card) {
 		return !card.isType(CardType.CAT_CARD)
 				&& !card.isType(CardType.EXPLODING_KITTEN)
-				&& !card.isType(CardType.DEFUSE);
+				&& !card.isType(CardType.DEFUSE)
+				&& !card.isType(CardType.NOPE);
 	}
 
 	private boolean isValidCatCombo(List<Card> cards) {
@@ -62,7 +63,6 @@ public class ComboValidator {
 		else if (card.isType(CardType.SHUFFLE)) { return new ShuffleAction(); }
 		else if (card.isType(CardType.SEE_THE_FUTURE)) { return new SeeTheFutureAction(helper); }
 		else if (card.isType(CardType.FAVOR)) { return new FavorAction(helper); }
-		else if (card.isType(CardType.NOPE)) { return new NopeAction(); }
 		else {
 			ResourceBundle bundle = ResourceBundle.getBundle("labels", Locale.getDefault());
 			throw new IllegalArgumentException(

--- a/src/test/java/domain/factory/ComboValidatorTest.java
+++ b/src/test/java/domain/factory/ComboValidatorTest.java
@@ -156,9 +156,9 @@ public class ComboValidatorTest {
 	}
 
 	@Test
-	void resolveAction_OneNope_ReturnsNopeAction() {
-		CardAction action = validator().resolveAction(List.of(card(CardType.NOPE, CardName.NOPE)));
-		assertInstanceOf(NopeAction.class, action);
+	void resolveAction_OneNope_ThrowsIllegalArgumentException() {
+		assertThrows(IllegalArgumentException.class,
+				() -> validator().resolveAction(List.of(card(CardType.NOPE, CardName.NOPE))));
 	}
 
 	@Test
@@ -194,5 +194,10 @@ public class ComboValidatorTest {
 		replay(unknownCard);
 		assertThrows(IllegalArgumentException.class,
 				() -> validator().resolveAction(List.of(unknownCard)));
+	}
+
+	@Test
+	void isValid_OneNope_ReturnsFalse() {
+		assertFalse(validator().isValid(List.of(card(CardType.NOPE, CardName.NOPE))));
 	}
 }


### PR DESCRIPTION
Addresses #100, part 1

- ensures that a player cannot just play a nope independently. It must be a reaction to another card