### PR TITLE
Fix/bva docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ OR
 ---
 ## Grading Notes
 - During Week 6, the weekly report was submitted as a PR but was not merged in time.
-  The Week 7 and 8 reports were also submitted late due to academic workload.
-  This was communicated to the Professor in advance, who advised us to note it here.
+  The Week 7 was submitted late due to academic workload.
+  This was communicated to the Professor in advance, who advised us to note it here and said that it was acceptable.
 
 
 ---

--- a/docs/bva/domain/factory/ComboValidator.md
+++ b/docs/bva/domain/factory/ComboValidator.md
@@ -18,7 +18,8 @@ spaces: collection size, card types
 cases:
 - null: false
 - empty (0 cards): false
-- one action card (SKIP, ATTACK, SHUFFLE, SEE_THE_FUTURE, FAVOR, NOPE): true
+- one action card (SKIP, ATTACK, SHUFFLE, SEE_THE_FUTURE, FAVOR): true
+- one NOPE: false
 - one CAT_CARD: false
 - one EXPLODING_KITTEN: false
 - one DEFUSE: false
@@ -35,6 +36,7 @@ cases:
 | isValid_NullList_ReturnsFalse                         | null passed                 | false           | :white_check_mark: |
 | isValid_EmptyList_ReturnsFalse                        | 0 cards                     | false           | :white_check_mark: |
 | isValid_OneActionCard_ReturnsTrue                     | 1 SKIP card                 | true            | :white_check_mark: |
+| isValid_OneNope_ReturnsFalse                          | 1 NOPE card                 | false           | :white_check_mark: |
 | isValid_OneCatCard_ReturnsFalse                       | 1 CAT_CARD                  | false           | :white_check_mark: |
 | isValid_OneExplodingKitten_ReturnsFalse               | 1 EXPLODING_KITTEN          | false           | :white_check_mark: |
 | isValid_OneDefuse_ReturnsFalse                        | 1 DEFUSE                    | false           | :white_check_mark: |
@@ -56,7 +58,7 @@ cases:
 - 1 SHUFFLE: ShuffleAction
 - 1 SEE_THE_FUTURE: SeeTheFutureAction
 - 1 FAVOR: FavorAction
-- 1 NOPE: NopeAction
+- 1 NOPE: IllegalArgumentException
 - 2 matching CAT_CARD: TwoCatAction
 - 3 matching CAT_CARD: ThreeCatAction
 - invalid combo: IllegalArgumentException
@@ -69,7 +71,7 @@ cases:
 | resolveAction_OneShuffle_ReturnsShuffleAction             | 1 SHUFFLE card         | ShuffleAction instance           | :white_check_mark: |
 | resolveAction_OneSeeFuture_ReturnsSeeTheFutureAction      | 1 SEE_THE_FUTURE card  | SeeTheFutureAction instance      | :white_check_mark: |
 | resolveAction_OneFavor_ReturnsFavorAction                 | 1 FAVOR card           | FavorAction instance             | :white_check_mark: |
-| resolveAction_OneNope_ReturnsNopeAction                   | 1 NOPE card            | NopeAction instance              | :white_check_mark: |
+| resolveAction_OneNope_ThrowsIllegalArgumentException      | 1 NOPE card            | IllegalArgumentException         | :white_check_mark: |
 | resolveAction_TwoMatchingCats_ReturnsTwoCatAction         | 2 TACO_CAT cards       | TwoCatAction instance            | :white_check_mark: |
 | resolveAction_ThreeMatchingCats_ReturnsThreeCatAction     | 3 TACO_CAT cards       | ThreeCatAction instance          | :white_check_mark: |
 | resolveAction_InvalidCombo_ThrowsIllegalArgumentException | invalid combo          | IllegalArgumentException         | :white_check_mark: |

--- a/docs/bva/domain/factory/ComboValidator.md
+++ b/docs/bva/domain/factory/ComboValidator.md
@@ -62,6 +62,7 @@ cases:
 - 2 matching CAT_CARD: TwoCatAction
 - 3 matching CAT_CARD: ThreeCatAction
 - invalid combo: IllegalArgumentException
+- valid combo but card type not handled by resolver: IllegalArgumentException
 - max size (N/A)
 
 | test_Name                                                 | State of the System    | Expected output                  | Implemented?       |
@@ -75,3 +76,4 @@ cases:
 | resolveAction_TwoMatchingCats_ReturnsTwoCatAction         | 2 TACO_CAT cards       | TwoCatAction instance            | :white_check_mark: |
 | resolveAction_ThreeMatchingCats_ReturnsThreeCatAction     | 3 TACO_CAT cards       | ThreeCatAction instance          | :white_check_mark: |
 | resolveAction_InvalidCombo_ThrowsIllegalArgumentException | invalid combo          | IllegalArgumentException         | :white_check_mark: |
+| resolveAction_ValidButUnhandledCardType_ThrowsIllegalArgumentException | valid 1-card combo, unhandled CardType | IllegalArgumentException | :white_check_mark: |

--- a/docs/bva/domain/model/GameState.md
+++ b/docs/bva/domain/model/GameState.md
@@ -237,10 +237,12 @@ spaces: delegates to deck (not in BVA catalog — boundary cases covered by Deck
 
 cases:
 - delegates shuffle to the deck
+- calls shuffle() on the deck exactly once
 
-| test_Name                          | State of the System | Expected output | Implemented?       |
-|------------------------------------|---------------------|-----------------|--------------------|
-| shuffleDeck_DelegatesShuffleToDeck | deck with 2+ cards  | void            | :white_check_mark: |
+| test_Name                          | State of the System | Expected output             | Implemented?       |
+|------------------------------------|---------------------|-----------------------------|--------------------|
+| shuffleDeck_DelegatesShuffleToDeck | deck with 2+ cards  | void                        | :white_check_mark: |
+| shuffleDeck_CallsShuffleOnDeck     | mocked deck         | deck.shuffle() invoked once | :white_check_mark: |
 
 
 


### PR DESCRIPTION
 - docs/bva/domain/factory/ComboValidator.md
    - Fixed isValid() section: removed NOPE from the "one action card → true" case (it actually returns false), added a new "one NOPE → false" case, and added the
  isValid_OneNope_ReturnsFalse row.
    - Fixed resolveAction() section: changed the "1 NOPE" expected output from NopeAction to IllegalArgumentException, and replaced the bogus resolveAction_OneNope_ReturnsNopeAction row
  with the real resolveAction_OneNope_ThrowsIllegalArgumentException.
    - Added resolveAction_ValidButUnhandledCardType_ThrowsIllegalArgumentException row with a new "valid combo but unhandled card type" case.
  - docs/bva/domain/model/GameState.md
    - Added shuffleDeck_CallsShuffleOnDeck row under shuffleDeck() with a "calls shuffle() exactly once" case.
  - README.md
    - Corrected the Grading Notes: only Week 7 was late (Week 8 was on time); added confirmation that the late submission was approved.