### PR TITLE
fix: resolve nope window bugs - recursive chain and active player participation

### DIFF
--- a/src/main/java/domain/model/GameState.java
+++ b/src/main/java/domain/model/GameState.java
@@ -140,6 +140,10 @@ public class GameState {
 		return Collections.unmodifiableList(others);
 	}
 
+	public List<Player> getAllActivePlayers() {
+		return Collections.unmodifiableList(new ArrayList<>(activePlayers));
+	}
+
 	public List<Card> peekTopOfDeck(int n) {
 		return deck.peekTop(n);
 	}

--- a/src/main/java/domain/model/TurnState.java
+++ b/src/main/java/domain/model/TurnState.java
@@ -32,6 +32,7 @@ public class TurnState {
 			throw new IllegalArgumentException(bundle.getString("error.card.arg.null"));
 		}
 		pendingAction = card;
+		nopeCount = 0;
 	}
 
 	public void clearPendingAction() {

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -283,16 +283,22 @@ public class GameController {
 	}
 
 	private void applyNopeWindow(TurnState turnState) {
-		List<Player> others = gameState.getOtherActivePlayers();
-		for (Player player : others) {
-			if (player.hasCard(CardType.NOPE)){
-				if (input.promptNope(player)) {
-					player.removeCardOfType(CardType.NOPE);
-					turnState.incrementNopeCount();
-				}
-			}
-
+		boolean anyNopeThisRound = runNopeRound(gameState.getOtherActivePlayers(), turnState);
+		while (anyNopeThisRound) {
+			anyNopeThisRound = runNopeRound(gameState.getAllActivePlayers(), turnState);
 		}
+	}
+
+	private boolean runNopeRound(List<Player> players, TurnState turnState) {
+		boolean anyNopeThisRound = false;
+		for (Player player : players) {
+			if (player.hasCard(CardType.NOPE) && input.promptNope(player)) {
+				player.removeCardOfType(CardType.NOPE);
+				turnState.incrementNopeCount();
+				anyNopeThisRound = true;
+			}
+		}
+		return anyNopeThisRound;
 	}
 
 	public void drawCard() {

--- a/src/test/java/domain/model/GameStateTest.java
+++ b/src/test/java/domain/model/GameStateTest.java
@@ -312,6 +312,31 @@ public class GameStateTest {
 	}
 
 	@Test
+	public void getAllActivePlayers_TwoPlayers_ReturnsBothPlayers() {
+		Player first = new Player("p1", "Caroline");
+		Player second = new Player("p2", "Mercy");
+		GameState gs = new GameState(List.of(first, second), emptyDeck());
+		assertEquals(List.of(first, second), gs.getAllActivePlayers());
+	}
+
+	@Test
+	public void getAllActivePlayers_MultiplePlayers_ReturnsAllPlayers() {
+		Player first = new Player("p1", "Caroline");
+		Player second = new Player("p2", "Mercy");
+		Player third = new Player("p3", "Chibu");
+		GameState gs = new GameState(List.of(first, second, third), emptyDeck());
+		assertEquals(List.of(first, second, third), gs.getAllActivePlayers());
+	}
+
+	@Test
+	public void getAllActivePlayers_IncludesCurrentPlayer() {
+		Player first = new Player("p1", "Caroline");
+		Player second = new Player("p2", "Mercy");
+		GameState gs = new GameState(List.of(first, second), emptyDeck());
+		assertTrue(gs.getAllActivePlayers().contains(first));
+	}
+
+	@Test
 	public void getOtherActivePlayers_TwoPlayers_ReturnsListWithOnePlayer() {
 		Player first = new Player("p1", "Caroline");
 		Player second = new Player("p2", "Mercy");

--- a/src/test/java/domain/model/TurnStateTest.java
+++ b/src/test/java/domain/model/TurnStateTest.java
@@ -92,6 +92,15 @@ public class TurnStateTest {
 	}
 
 	@Test
+	void setPendingAction_AfterNopesAccumulated_ResetsNopeCountToZero() {
+		TurnState turnState = new TurnState();
+		turnState.incrementNopeCount();
+		turnState.incrementNopeCount();
+		turnState.setPendingAction(anyCard());
+		assertEquals(0, turnState.nopeCount());
+	}
+
+	@Test
 	void clearPendingAction_WhenSet_ClearsToEmpty() {
 		TurnState turnState = new TurnState();
 		turnState.setPendingAction(anyCard());

--- a/src/test/java/ui/AttackIntegrationTest.java
+++ b/src/test/java/ui/AttackIntegrationTest.java
@@ -33,8 +33,6 @@ public class AttackIntegrationTest {
 	private static final int THREE_TURNS = 3;
 	private static final int FOUR_TURNS = 4;
 	private static final int SIX_TURNS = 6;
-	private static final int THREE_TIMES = 3;
-
 	private static ComboValidator realComboValidator(IPlayerInput input) {
 		return new ComboValidator(new PlayerInteractionHelper(input, new Random()));
 	}
@@ -118,7 +116,9 @@ public class AttackIntegrationTest {
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(attackCard)).once();
 		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
-				.andReturn(true);
+				.andReturn(true)   // other player nopes the attack in round 1
+				.andReturn(false)  // active player declines counter-nope in round 2
+				.andReturn(false); // other player still has nopes but declines counter-nope in round 2
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 
@@ -246,12 +246,18 @@ public class AttackIntegrationTest {
 				.andReturn(List.of(attackCard))
 				.andReturn(List.of(shuffleCard1));
 		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
+				// p1 attack round 1: both others decline
 				.andReturn(false).times(TWO_PLAYERS)
+				// p2 attack round 1: first other declines, second nopes (nopeCount=1)
 				.andReturn(false).times(ONE_PLAYER)
 				.andReturn(true).times(ONE_PLAYER)
+				// p2 attack round 2: all 3 still have nopes, all decline
+				.andReturn(false).times(THREE_PLAYERS)
+				// p2 shuffle round 1: others decline, shuffle executes (nopeCount reset per card)
 				.andReturn(false).times(TWO_PLAYERS);
+		// attacked msg + attack noped (shuffle executes cleanly on its own nopeCount)
 		display.showMessage(EasyMock.anyString());
-		EasyMock.expectLastCall().times(THREE_TIMES);
+		EasyMock.expectLastCall().times(TWO_TURNS);
 
 		EasyMock.replay(display, input);
 
@@ -402,10 +408,15 @@ public class AttackIntegrationTest {
 				.andReturn(List.of(shuffleCard1))
 				.andReturn(List.of(attackCard));
 		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
+				// p1 attack round 1: both others decline
 				.andReturn(false).times(TWO_PLAYERS)
+				// p2 shuffle round 1: both others decline
 				.andReturn(false).times(TWO_PLAYERS)
+				// p2 attack round 1: first other declines, second nopes
 				.andReturn(false).times(ONE_PLAYER)
-				.andReturn(true).times(ONE_PLAYER);
+				.andReturn(true).times(ONE_PLAYER)
+				// p2 attack round 2: all 3 still have nopes, all decline
+				.andReturn(false).times(THREE_PLAYERS);
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().times(2);
 

--- a/src/test/java/ui/FavorIntegrationTest.java
+++ b/src/test/java/ui/FavorIntegrationTest.java
@@ -194,7 +194,10 @@ public class FavorIntegrationTest {
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(favorCard)).once();
 
-		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class))).andReturn(true);
+		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
+				.andReturn(true)   // other player nopes the favor in round 1
+				.andReturn(false)  // active player declines counter-nope in round 2
+				.andReturn(false); // other player still has nopes but declines counter-nope in round 2
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 

--- a/src/test/java/ui/GameControllerTest.java
+++ b/src/test/java/ui/GameControllerTest.java
@@ -103,9 +103,11 @@ public class GameControllerTest {
 
 	private void expectNopedPlaySetup(List<Card> cards, TurnState turnState) {
 		Player other = otherPlayer();
+		Player current = new Player("p1", "Current Player");
 		expectBasePlaySetup(cards, turnState);
 		EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(List.of(other));
 		EasyMock.expect(mockInput.promptNope(other)).andReturn(true);
+		EasyMock.expect(mockGameState.getAllActivePlayers()).andReturn(List.of(current, other));
 		mockDisplay.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 	}
@@ -122,6 +124,19 @@ public class GameControllerTest {
 	@Test
 	void playCard_EmptyList_ShowsErrorMessage() {
 		List<Card> cards = Collections.emptyList();
+		EasyMock.expect(mockValidator.isValid(cards)).andReturn(false);
+		mockDisplay.showMessage(EasyMock.anyString());
+		EasyMock.expectLastCall().once();
+		EasyMock.replay(mockGameState, mockDisplay, mockInput, mockValidator);
+
+		controller.playCard(cards);
+
+		EasyMock.verify(mockGameState, mockDisplay, mockInput, mockValidator);
+	}
+
+	@Test
+	void playCard_SingleNope_ShowsErrorMessage() {
+		List<Card> cards = List.of(new Card(CardType.NOPE, CardName.NOPE, new NoAction()));
 		EasyMock.expect(mockValidator.isValid(cards)).andReturn(false);
 		mockDisplay.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
@@ -359,6 +374,7 @@ public class GameControllerTest {
 	void applyNopeWindow_MultiplePlayers_OneNopes_NopeCountIsOne() {
 		List<Card> cards = List.of(skipCard());
 		TurnState turnState = new TurnState();
+		Player current = new Player("p0", "Current Player");
 		Player p1 = new Player("p1", "Player 1");
 		Player p2 = new Player("p2", "Player 2");
 		Player p3 = new Player("p3", "Player 3");
@@ -372,6 +388,9 @@ public class GameControllerTest {
 		EasyMock.expect(mockGameState.getOtherActivePlayers()).andReturn(List.of(p1, p2, p3));
 		EasyMock.expect(mockInput.promptNope(p1)).andReturn(false);
 		EasyMock.expect(mockInput.promptNope(p2)).andReturn(true);
+		EasyMock.expect(mockInput.promptNope(p3)).andReturn(false);
+		EasyMock.expect(mockGameState.getAllActivePlayers()).andReturn(List.of(current, p1, p2, p3));
+		EasyMock.expect(mockInput.promptNope(p1)).andReturn(false);
 		EasyMock.expect(mockInput.promptNope(p3)).andReturn(false);
 		mockDisplay.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
@@ -388,6 +407,7 @@ public class GameControllerTest {
 		final int expectedNopeCount = 3;
 		List<Card> cards = List.of(skipCard());
 		TurnState turnState = new TurnState();
+		Player current = new Player("p0", "Current Player");
 		Player p1 = new Player("p1", "Player 1");
 		Player p2 = new Player("p2", "Player 2");
 		Player p3 = new Player("p3", "Player 3");
@@ -402,6 +422,7 @@ public class GameControllerTest {
 		EasyMock.expect(mockInput.promptNope(p1)).andReturn(true);
 		EasyMock.expect(mockInput.promptNope(p2)).andReturn(true);
 		EasyMock.expect(mockInput.promptNope(p3)).andReturn(true);
+		EasyMock.expect(mockGameState.getAllActivePlayers()).andReturn(List.of(current, p1, p2, p3));
 		mockDisplay.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 		EasyMock.replay(mockGameState, mockDisplay, mockInput, mockValidator);

--- a/src/test/java/ui/NopeIntegrationTest.java
+++ b/src/test/java/ui/NopeIntegrationTest.java
@@ -27,7 +27,6 @@ public class NopeIntegrationTest {
 	private static final int TWO_PLAYERS = 2;
 	private static final int TWO_TURNS = 2;
 	private static final int ONE_CARD = 1;
-	private static final int ONE_PLAYER = 1;
 	private static final int THREE_PLAYERS = 3;
 	private static final int FOUR_PLAYERS = 4;
 
@@ -106,7 +105,9 @@ public class NopeIntegrationTest {
 				.andReturn(PlayerChoice.DONE_PLAYING_CARDS);
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(skipCard)).once();
-		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class))).andReturn(true).once();
+		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
+				.andReturn(true)   // other player nopes in round 1
+				.andReturn(false); // active player declines counter-nope in round 2
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 
@@ -139,11 +140,7 @@ public class NopeIntegrationTest {
 		Card skipCard = new Card(CardType.SKIP, CardName.SKIP, new SkipAction());
 		Card cattermelonCard = new Card(CardType.CAT_CARD, CardName.CATTERMELON, new NoAction());
 		Card nopeCard1 = new Card(CardType.NOPE, CardName.NOPE, new NoAction());
-		Card nopeCard2 = new Card(CardType.NOPE, CardName.NOPE, new NoAction());
-		Card nopeCard3 = new Card(CardType.NOPE, CardName.NOPE, new NoAction());
 		playerHandCards.add(nopeCard1);
-		playerHandCards.add(nopeCard2);
-		playerHandCards.add(nopeCard3);
 		drawPileCards.add(skipCard);
 		drawPileCards.add(cattermelonCard);
 		drawPileCards.add(shuffleCard);
@@ -157,8 +154,9 @@ public class NopeIntegrationTest {
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(skipCard)).once();
 		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
-				.andReturn(true)
-				.andReturn(true);
+				.andReturn(true)   // other player 1 nopes in round 1
+				.andReturn(true)   // other player 2 nopes in round 1
+				.andReturn(false); // active player declines counter-nope in round 2
 
 		EasyMock.replay(display, input);
 
@@ -191,11 +189,7 @@ public class NopeIntegrationTest {
 		Card skipCard = new Card(CardType.SKIP, CardName.SKIP, new SkipAction());
 		Card cattermelonCard = new Card(CardType.CAT_CARD, CardName.CATTERMELON, new NoAction());
 		Card nopeCard1 = new Card(CardType.NOPE, CardName.NOPE, new NoAction());
-		Card nopeCard2 = new Card(CardType.NOPE, CardName.NOPE, new NoAction());
-		Card nopeCard3 = new Card(CardType.NOPE, CardName.NOPE, new NoAction());
 		playerHandCards.add(nopeCard1);
-		playerHandCards.add(nopeCard2);
-		playerHandCards.add(nopeCard3);
 		drawPileCards.add(skipCard);
 		drawPileCards.add(cattermelonCard);
 		drawPileCards.add(shuffleCard);
@@ -209,9 +203,10 @@ public class NopeIntegrationTest {
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(skipCard)).once();
 		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
-				.andReturn(true)
-				.andReturn(true)
-				.andReturn(true);
+				.andReturn(true)   // other player 1 nopes in round 1
+				.andReturn(true)   // other player 2 nopes in round 1
+				.andReturn(true)   // other player 3 nopes in round 1
+				.andReturn(false); // active player declines counter-nope in round 2
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 
@@ -235,7 +230,7 @@ public class NopeIntegrationTest {
 	}
 
 	@Test
-	void nope_ThreePlayers_OneLeftWithNope_OnlyOnePlayerPrompted(){
+	void nope_FourPlayers_MultiTurn_ActivePlayerParticipatesInNopeChain(){
 		IGameDisplay display = EasyMock.createMock(IGameDisplay.class);
 		IPlayerInput input = EasyMock.createMock(IPlayerInput.class);
 		List<Card> playerHandCards = new ArrayList<>();
@@ -267,10 +262,14 @@ public class NopeIntegrationTest {
 				.andReturn(List.of(skipCard1))
 				.andReturn(List.of(skipCard2));
 		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
-				.andReturn(true).times(TWO_PLAYERS)
-				.andReturn(false).times(ONE_PLAYER)
-				.andReturn(true).times(ONE_PLAYER)
-				.andReturn(false).times(ONE_PLAYER);
+				.andReturn(true)   // turn 1 round 1: player 2 nopes
+				.andReturn(true)   // turn 1 round 1: player 3 nopes (nopeCount=2, even)
+				.andReturn(false)  // turn 1 round 1: player 4 declines
+				.andReturn(false)  // turn 1 round 2: player 1 (active) declines counter-nope
+				.andReturn(false)  // turn 1 round 2: player 4 declines
+				.andReturn(true)   // turn 2 round 1: player 1 nopes (nopeCount=1, odd)
+				.andReturn(false)  // turn 2 round 1: player 4 declines
+				.andReturn(false); // turn 2 round 2: player 4 is last with a nope, declines
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 
@@ -296,8 +295,6 @@ public class NopeIntegrationTest {
 		assertNotEquals(secondPlayer, thirdPlayer);
 
 		EasyMock.verify(display, input);
-
-
 	}
 
 

--- a/src/test/java/ui/PlayATurnIntegrationTest.java
+++ b/src/test/java/ui/PlayATurnIntegrationTest.java
@@ -50,7 +50,10 @@ public class PlayATurnIntegrationTest {
 		cards.add(nopeCard1);
 		cards.add(nopeCard2);
 		cards.add(nopeCard3);
-		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class))).andReturn(true);
+		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
+				.andReturn(true)   // other player nopes the skip in round 1
+				.andReturn(false)  // active player declines counter-nope in round 2
+				.andReturn(false); // other player still has nopes but declines counter-nope in round 2
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(skipCard)).once();
 		display.showMessage(EasyMock.anyString());

--- a/src/test/java/ui/SeeTheFutureIntegrationTest.java
+++ b/src/test/java/ui/SeeTheFutureIntegrationTest.java
@@ -115,7 +115,10 @@ public class SeeTheFutureIntegrationTest {
 				.andReturn(PlayerChoice.DONE_PLAYING_CARDS);
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(seeTheFutureCard)).once();
-		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class))).andReturn(true);
+		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
+				.andReturn(true)   // other player nopes seeTheFuture in round 1
+				.andReturn(false)  // active player declines counter-nope in round 2
+				.andReturn(false); // other player still has nopes but declines counter-nope in round 2
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 

--- a/src/test/java/ui/ShuffleIntegrationTest.java
+++ b/src/test/java/ui/ShuffleIntegrationTest.java
@@ -63,7 +63,10 @@ public class ShuffleIntegrationTest {
 				.andReturn(PlayerChoice.DONE_PLAYING_CARDS);
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(shuffleCard)).once();
-		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class))).andReturn(true);
+		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
+				.andReturn(true)   // other player nopes the shuffle in round 1
+				.andReturn(false)  // active player declines counter-nope in round 2
+				.andReturn(false); // other player still has nopes but declines counter-nope in round 2
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 

--- a/src/test/java/ui/SkipIntegrationTest.java
+++ b/src/test/java/ui/SkipIntegrationTest.java
@@ -107,7 +107,10 @@ public class SkipIntegrationTest {
 				.andReturn(PlayerChoice.DONE_PLAYING_CARDS);
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(skipCard)).once();
-		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class))).andReturn(true);
+		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
+				.andReturn(true)   // other player nopes the skip in round 1
+				.andReturn(false)  // active player declines counter-nope in round 2
+				.andReturn(false); // other player still has nopes but declines counter-nope in round 2
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 
@@ -156,8 +159,13 @@ public class SkipIntegrationTest {
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(skipCard)).once();
 		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
-				.andReturn(true)
-				.andReturn(true);
+				// round 1: both other players nope (nopeCount=2, even: skip executes)
+				.andReturn(true)   // other player 1 nopes
+				.andReturn(true)   // other player 2 nopes
+				// round 2: all 3 players still have nopes, all decline
+				.andReturn(false)  // active player declines
+				.andReturn(false)  // other player 1 declines
+				.andReturn(false); // other player 2 declines
 
 		EasyMock.replay(display, input);
 
@@ -204,9 +212,15 @@ public class SkipIntegrationTest {
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(skipCard)).once();
 		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
-				.andReturn(true)
-				.andReturn(true)
-				.andReturn(true);
+				// round 1: all 3 other players nope (nopeCount=3, odd: skip noped)
+				.andReturn(true)   // other player 1 nopes
+				.andReturn(true)   // other player 2 nopes
+				.andReturn(true)   // other player 3 nopes
+				// round 2: all 4 players still have nopes, all decline
+				.andReturn(false)  // active player declines
+				.andReturn(false)  // other player 1 declines
+				.andReturn(false)  // other player 2 declines
+				.andReturn(false); // other player 3 declines
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 

--- a/src/test/java/ui/ThreeCardIntegrationTest.java
+++ b/src/test/java/ui/ThreeCardIntegrationTest.java
@@ -209,7 +209,10 @@ public class ThreeCardIntegrationTest {
 		EasyMock.expect(input.promptCardSelection(EasyMock.isA(Player.class)))
 				.andReturn(List.of(cattermelon1, cattermelon2, cattermelon3)).once();
 
-		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class))).andReturn(true);
+		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
+				.andReturn(true)   // other player nopes the three-card combo in round 1
+				.andReturn(false)  // active player declines counter-nope in round 2
+				.andReturn(false); // other player still has nopes but declines counter-nope in round 2
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 

--- a/src/test/java/ui/TwoCardIntegrationTest.java
+++ b/src/test/java/ui/TwoCardIntegrationTest.java
@@ -140,7 +140,10 @@ public class TwoCardIntegrationTest {
 				.andReturn(List.of(cattermelon1, cattermelon2)).once();
 
 
-		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class))).andReturn(true);
+		EasyMock.expect(input.promptNope(EasyMock.isA(Player.class)))
+				.andReturn(true)   // other player nopes the two-card combo in round 1
+				.andReturn(false)  // active player declines counter-nope in round 2
+				.andReturn(false); // other player still has nopes but declines counter-nope in round 2
 		display.showMessage(EasyMock.anyString());
 		EasyMock.expectLastCall().once();
 


### PR DESCRIPTION
Closes #100

## Summary

- Added `getAllActivePlayers()` to `GameState` to expose all active players including the current player
- Refactored `applyNopeWindow` in `GameController` to run recursively: round 1 asks non-active players, subsequent rounds ask all players (including the active player), looping until a full round passes with no new nopes
- Fixed a pre-existing `nopeCount` carry-over bug where nope state from one card play leaked into the next play in the same turn — `setPendingAction` now resets `nopeCount` to zero

## Test plan

- [x] All 409 tests pass
- [x] Nope played as a standalone action is rejected (Bug 1 — covered by `ComboValidator` + `playCard_SingleNope_ShowsErrorMessage`)
- [x] Active player can counter-nope after opponents nope their card (Bug 2 — covered by `NopeIntegrationTest.nope_FourPlayers_MultiTurn_ActivePlayerParticipatesInNopeChain`)
- [x] Nope chain terminates only after a full round with no new nopes (covered by `nope_TwoNopes_CardExecuted`, `nope_ThreeNopes_CardNotExecuted`)
- [x] Playing a second card in the same turn starts with a fresh nope count (covered by `setPendingAction_AfterNopesAccumulated_ResetsNopeCountToZero`)
- [x] Checkstyle and SpotBugs both pass